### PR TITLE
Replacing GceOperation ans __ExecuteOperation with BlockOperation whi…

### DIFF
--- a/libcloudforensics/gcp.py
+++ b/libcloudforensics/gcp.py
@@ -31,7 +31,7 @@ import ssl
 import subprocess
 import time
 
-from apiclient.discovery import build  # pylint: disable=import-error
+from googleapiclient.discovery import build  # pylint: disable=import-error
 from googleapiclient.errors import HttpError
 from oauth2client.client import AccessTokenRefreshError
 from oauth2client.client import GoogleCredentials
@@ -61,9 +61,10 @@ def CreateService(service_name, api_version):
   try:
     credentials = GoogleCredentials.get_application_default()
   except ApplicationDefaultCredentialsError as error:
-    error_msg = 'Could not get application default credentials: {0!s}\n' \
-                'Have you run $ gcloud auth application-default '\
-                'login?'.format(error)
+    error_msg = (
+        'Could not get application default credentials: {0!s}\n'
+        'Have you run $ gcloud auth application-default '
+        'login?').format(error)
     raise RuntimeError(error_msg)
 
   service_built = False
@@ -82,8 +83,9 @@ def CreateService(service_name, api_version):
       break
 
   if not service_built:
-    error_msg = 'Failures building service {0:s} caused by multiple '\
-                'timeouts'.format(service_name)
+    error_msg = (
+        'Failures building service {0:s} caused by multiple '
+        'timeouts').format(service_name)
     raise RuntimeError(error_msg)
 
   return service
@@ -95,6 +97,7 @@ class GoogleCloudProject:
   Attributes:
     project_id: Project name.
     default_zone: Default zone to create new resources in.
+    gce_api_client: Client to interact with GCE APIs.
 
   Example use:
     gcp = GoogleCloudProject("your_project_name", "us-east")
@@ -112,41 +115,7 @@ class GoogleCloudProject:
     """
     self.project_id = project_id
     self.default_zone = default_zone
-
-  def __ExecuteOperation(self, service, operation, zone, block):
-    """Executes API calls.
-
-    Args:
-      service (apiclient.discovery.Resource): API service resource.
-      operation (str): API operation to be executed.
-      zone (str): GCP zone to execute the operation in. None means GlobalZone.
-      block (bool): Boolean indicating if the operation should block before
-      return.
-
-    Returns:
-      str: Operation result in JSON format.
-
-    Raises:
-      RuntimeError: If API call failed.
-    """
-    if not block:
-      return operation
-
-    while True:
-      if zone:
-        result = service.zoneOperations().get(
-            project=self.project_id, zone=zone,
-            operation=operation['name']).execute()
-      else:
-        result = service.globalOperations().get(
-            project=self.project_id, operation=operation['name']).execute()
-
-      if 'error' in result:
-        raise RuntimeError(result['error'])
-
-      if not block or result['status'] == 'DONE':
-        return result
-      time.sleep(5)  # Seconds between requests
+    self.gce_api_client = None
 
   def GceApi(self):
     """Get a Google Compute Engine service object.
@@ -154,22 +123,42 @@ class GoogleCloudProject:
     Returns:
       apiclient.discovery.Resource: A Google Compute Engine service object.
     """
-    return CreateService('compute', self.COMPUTE_ENGINE_API_VERSION)
+    if self.gce_api_client:
+      return self.gce_api_client
+    self.gce_api_client = CreateService(
+        'compute', self.COMPUTE_ENGINE_API_VERSION)
+    return self.gce_api_client
 
-  def GceOperation(self, operation, zone=None, block=False):
-    """Convenient method for GCE operation.
+  def BlockOperation(self, response, zone=None):
+    """Executes API calls.
 
     Args:
-      operation (str): Operation to be executed.
-      zone (str): GCP zone to execute the operation in. 'None' means global
-      operation.
-      block (bool): Boolean indicating if the operation should block before
-      return.
+      response (dict): GCE API response.
+      zone (str): GCP zone to execute the operation in. None means GlobalZone.
 
     Returns:
       str: Operation result in JSON format.
+
+    Raises:
+      RuntimeError: If API call failed.
     """
-    return self.__ExecuteOperation(self.GceApi(), operation, zone, block)
+    service = self.GceApi()
+    while True:
+      if zone:
+        request = service.zoneOperations().get(
+            project=self.project_id, zone=zone, operation=response['name'])
+        result = request.execute()
+      else:
+        request = service.globalOperations().get(
+            project=self.project_id, operation=response['name'])
+        result = request.execute()
+
+      if 'error' in result:
+        raise RuntimeError(result['error'])
+
+      if result['status'] == 'DONE':
+        return result
+      time.sleep(5)  # Seconds between requests
 
   def FormatLogMessage(self, message):
     """Format log messages with project specific information.
@@ -188,18 +177,17 @@ class GoogleCloudProject:
     Returns:
       dict: Dictionary with name and metadata for each instance.
     """
-    # TODO(aarontp): Refactor out the duplicate code used by multiple methods
     have_all_tokens = False
     page_token = None
     instances = dict()
     while not have_all_tokens:
+      gce_instance_client = self.GceApi().instances()
       if page_token:
-        operation = self.GceApi().instances().aggregatedList(
-            project=self.project_id, pageToken=page_token).execute()
+        request = gce_instance_client.aggregatedList(
+            project=self.project_id, pageToken=page_token)
       else:
-        operation = self.GceApi().instances().aggregatedList(
-            project=self.project_id).execute()
-      result = self.GceOperation(operation, zone=self.default_zone)
+        request = gce_instance_client.aggregatedList(project=self.project_id)
+      result = request.execute()
       page_token = result.get('nextPageToken')
       if not page_token:
         have_all_tokens = True
@@ -224,13 +212,13 @@ class GoogleCloudProject:
     page_token = None
     disks = dict()
     while not have_all_tokens:
+      gce_disk_client = self.GceApi().disks()
       if page_token:
-        operation = self.GceApi().disks().aggregatedList(
-            project=self.project_id, pageToken=page_token).execute()
+        request = gce_disk_client.aggregatedList(
+            project=self.project_id, pageToken=page_token)
       else:
-        operation = self.GceApi().disks().aggregatedList(
-            project=self.project_id).execute()
-      result = self.GceOperation(operation, zone=self.default_zone)
+        request = gce_disk_client.aggregatedList(project=self.project_id)
+      result = request.execute()
       page_token = result.get('nextPageToken')
       if not page_token:
         have_all_tokens = True
@@ -312,17 +300,19 @@ class GoogleCloudProject:
       disk_name = GenerateDiskName(snapshot, disk_name_prefix)
     body = dict(name=disk_name, sourceSnapshot=snapshot.GetSourceString())
     try:
-      operation = self.GceApi().disks().insert(
-          project=self.project_id, zone=self.default_zone, body=body).execute()
+      gce_disks_client = self.GceApi().disks()
+      request = gce_disks_client.insert(
+          project=self.project_id, zone=self.default_zone, body=body)
+      response = request.execute()
     except HttpError as exception:
       if exception.resp.status == 409:
         error_msg = 'Disk {0:s} already exists'.format(disk_name)
         raise RuntimeError(error_msg)
-      error_msg = 'Unknown error (status: {0:d}) occurred when creating disk ' \
-                  'from Snapshot:\n{1!s}'.format(
-                      exception.resp.status, exception)
+      error_msg = (
+          'Unknown error (status: {0:d}) occurred when creating disk '
+          'from Snapshot:\n{1!s}').format(exception.resp.status, exception)
       raise RuntimeError(error_msg)
-    self.GceOperation(operation, zone=self.default_zone, block=True)
+    self.BlockOperation(response, zone=self.default_zone)
     return GoogleComputeDisk(
         project=self, zone=self.default_zone, name=disk_name)
 
@@ -337,9 +327,9 @@ class GoogleCloudProject:
       boot_disk_size (int): The size of the analysis VM boot disk (in GB).
       cpu_cores (int): Number of CPU cores for the virtual machine.
       image_project (str): Name of the project where the analysis VM image is
-      hosted.
+        hosted.
       image_family (str): Name of the image to use to create the analysis VM.
-      packages (list(str)): List of packages to install in the VM
+      packages (list[str]): List of packages to install in the VM.
 
     Returns:
       tuple(GoogleComputeInstance, bool): A tuple with a virtual machine object
@@ -361,9 +351,8 @@ class GoogleCloudProject:
 
     machine_type = 'zones/{0}/machineTypes/n1-standard-{1:d}'.format(
         self.default_zone, cpu_cores)
-    get_image_operation = self.GceApi().images().getFromFamily(
+    ubuntu_image = self.GceApi().images().getFromFamily(
         project=image_project, family=image_family).execute()
-    ubuntu_image = self.GceOperation(get_image_operation, block=False)
     source_disk_image = ubuntu_image['selfLink']
 
     startup_script = self._ReadStartupScript()
@@ -383,7 +372,8 @@ class GoogleCloudProject:
             }
         }],
         'networkInterfaces': [{
-            'network': 'global/networks/default',
+            'network':
+                'global/networks/default',
             'accessConfigs': [{
                 'type': 'ONE_TO_ONE_NAT',
                 'name': 'External NAT'
@@ -405,9 +395,11 @@ class GoogleCloudProject:
             }]
         }
     }
-    operation = self.GceApi().instances().insert(
-        project=self.project_id, zone=self.default_zone, body=config).execute()
-    self.GceOperation(operation, zone=self.default_zone, block=True)
+    gce_instance_client = self.GceApi().instances()
+    request = gce_instance_client.insert(
+        project=self.project_id, zone=self.default_zone, body=config)
+    response = request.execute()
+    self.BlockOperation(response, zone=self.default_zone)
     instance = GoogleComputeInstance(
         project=self, zone=self.default_zone, name=vm_name)
     created = True
@@ -451,8 +443,7 @@ class GoogleCloudProject:
     """
 
     disk_service_object = self.GceApi().disks()
-    return self.__ListByLabel(
-        labels_filter, disk_service_object, filter_union)
+    return self.__ListByLabel(labels_filter, disk_service_object, filter_union)
 
   def __ListByLabel(self, labels_filter, service_object, filter_union):
     """List Disks/VMs in a project with one/all of the provided labels.
@@ -475,8 +466,9 @@ class GoogleCloudProject:
       RuntimeError: if the operation doesn't complete on GCP.
     """
     if not isinstance(filter_union, bool):
-      error_msg = 'filter_union parameter must be of Type boolean {0:s} is an '\
-                  'invalid argument.'.format(filter_union)
+      error_msg = (
+          'filter_union parameter must be of Type boolean {0:s} is an '
+          'invalid argument.').format(filter_union)
       raise RuntimeError(error_msg)
 
     resource_dict = dict()
@@ -491,9 +483,8 @@ class GoogleCloudProject:
         project=self.project_id, filter=filter_expression)
     while request is not None:
       response = request.execute()
-      result = self.GceOperation(response, zone=self.default_zone)
 
-      for item in result['items'].items():
+      for item in response['items'].items():
         region_or_zone_string, resource_scoped_list = item
 
         if 'warning' not in resource_scoped_list.keys():
@@ -531,15 +522,17 @@ class GoogleCloudProject:
       startup_script = os.environ.get('STARTUP_SCRIPT')
       if not startup_script:
         # Use the provided script
-        startup_script = os.path.join(os.path.dirname(os.path.dirname(
-            os.path.realpath(__file__))), STARTUP_SCRIPT)
+        startup_script = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+            STARTUP_SCRIPT)
       startup_script = open(startup_script)
       script = startup_script.read()
       startup_script.close()
       return script
     except OSError as exception:
-      raise OSError('Could not open/read/close the startup script {0:s}: '
-                    '{1:s}'.format(startup_script, str(exception)))
+      raise OSError(
+          'Could not open/read/close the startup script {0:s}: '
+          '{1:s}'.format(startup_script, str(exception)))
 
 
 class GoogleCloudFunction(GoogleCloudProject):
@@ -547,6 +540,7 @@ class GoogleCloudFunction(GoogleCloudProject):
 
   Attributes:
     region (str): Region to execute functions in.
+    gcf_api_client: Client to interact with GCF APIs.
   """
 
   CLOUD_FUNCTIONS_API_VERSION = 'v1beta2'
@@ -559,6 +553,7 @@ class GoogleCloudFunction(GoogleCloudProject):
       region (str): Region to run functions in.
     """
     self.region = region
+    self.gcf_api_client = None
     super(GoogleCloudFunction, self).__init__(project_id)
 
   def GcfApi(self):
@@ -567,7 +562,11 @@ class GoogleCloudFunction(GoogleCloudProject):
     Returns:
       apiclient.discovery.Resource: A Google Cloud Function service object.
     """
-    return CreateService('cloudfunctions', self.CLOUD_FUNCTIONS_API_VERSION)
+    if self.gce_api_client:
+      return self.gce_api_client
+    self.gce_api_client = CreateService(
+        'cloudfunctions', self.CLOUD_FUNCTIONS_API_VERSION)
+    return self.gce_api_client
 
   def ExecuteFunction(self, function_name, args):
     """Executes a Google Cloud Function.
@@ -589,8 +588,9 @@ class GoogleCloudFunction(GoogleCloudProject):
     try:
       json_args = json.dumps(args)
     except TypeError as e:
-      error_msg = 'Cloud function args [{0:s}] could not be serialized:' \
-                  ' {1!s}'.format(str(args), e)
+      error_msg = (
+          'Cloud function args [{0:s}] could not be serialized:'
+          ' {1!s}').format(str(args), e)
       raise RuntimeError(error_msg)
 
     function_path = 'projects/{0:s}/locations/{1:s}/functions/{2:s}'.format(
@@ -643,7 +643,7 @@ class GoogleComputeBaseResource:
     Returns:
       str: Value of key or None if key is missing.
     """
-    self._data = self.GetOperation().execute()  # pylint: disable=no-member
+    self._data = self.GetOperation()  # pylint: disable=no-member
     return self._data.get(key)
 
   def GetSourceString(self):
@@ -690,9 +690,10 @@ class GoogleComputeBaseResource:
     module = None
     if resource_type not in ['compute#instance', 'compute#Snapshot',
                              'compute#disk']:
-      error_msg = 'Compute resource Type {0:s} is not one of the defined ' \
-                  'types in libcloudforensics library ' \
-                  '(Instance, Disk or Snapshot) '.format(resource_type)
+      error_msg = (
+          'Compute resource Type {0:s} is not one of the defined '
+          'types in libcloudforensics library '
+          '(Instance, Disk or Snapshot).').format(resource_type)
       raise RuntimeError(error_msg)
     if resource_type == 'compute#instance':
       module = self.project.GceApi().instances()
@@ -711,7 +712,7 @@ class GoogleComputeBaseResource:
       dict: A dictionary of all labels.
     """
 
-    operation = self.GetOperation().execute()  # pylint: disable=no-member
+    operation = self.GetOperation()  # pylint: disable=no-member
 
     return operation.get('labels')
 
@@ -719,8 +720,8 @@ class GoogleComputeBaseResource:
     """Add or update labels of a compute resource.
 
     Args:
-      new_labels_dict (dict): A dictionary containing the labels to be added.
-          ex: {"incident_id": "1234abcd"}.
+      new_labels_dict (dict): A dictionary containing the labels to be added,
+          ex:{"incident_id": "1234abcd"}.
       blocking_call (bool): A boolean to decide whether the API call should
           be blocking or not, default is False.
 
@@ -732,7 +733,7 @@ class GoogleComputeBaseResource:
       disk or snapshot.
     """
 
-    get_operation = self.GetOperation().execute()  # pylint: disable=no-member
+    get_operation = self.GetOperation()  # pylint: disable=no-member
     label_fingerprint = get_operation['labelFingerprint']
 
     existing_labels_dict = dict()
@@ -740,32 +741,36 @@ class GoogleComputeBaseResource:
       existing_labels_dict = self.GetLabels()
     existing_labels_dict.update(new_labels_dict)
     labels_dict = existing_labels_dict
-    request_body = {'labels': labels_dict,
-                    'labelFingerprint': label_fingerprint}
+    request_body = {
+        'labels': labels_dict,
+        'labelFingerprint': label_fingerprint
+    }
 
     resource_type = self.GetResourceType()
-    operation = None
+    response = None
     if resource_type not in ['compute#instance', 'compute#Snapshot',
                              'compute#disk']:
-      error_msg = 'Compute resource Type {0:s} is not one of the defined ' \
-                  'types in libcloudforensics library ' \
-                  '(Instance, Disk or Snapshot) '.format(resource_type)
+      error_msg = (
+          'Compute resource Type {0:s} is not one of the defined '
+          'types in libcloudforensics library '
+          '(Instance, Disk or Snapshot) ').format(resource_type)
       raise RuntimeError(error_msg)
     if resource_type == 'compute#instance':
-      operation = self.FormOperation('setLabels')(
+      response = self.FormOperation('setLabels')(
           instance=self.name, project=self.project.project_id, zone=self.zone,
           body=request_body).execute()
     elif resource_type == 'compute#disk':
-      operation = self.FormOperation('setLabels')(
+      response = self.FormOperation('setLabels')(
           resource=self.name, project=self.project.project_id, zone=self.zone,
           body=request_body).execute()
     elif resource_type == 'compute#Snapshot':
-      operation = self.FormOperation('setLabels')(
+      response = self.FormOperation('setLabels')(
           resource=self.name, project=self.project.project_id,
           body=request_body).execute()
+    if blocking_call:
+      self.project.BlockOperation(response, zone=self.zone)
 
-    return self.project.GceOperation(
-        operation, zone=self.zone, block=blocking_call)
+    return response
 
 
 class GoogleComputeInstance(GoogleComputeBaseResource):
@@ -777,9 +782,11 @@ class GoogleComputeInstance(GoogleComputeBaseResource):
     Returns:
        str: An API operation object for a Google Compute Engine virtual machine.
     """
-    operation = self.project.GceApi().instances().get(
+    gce_instance_client = self.project.GceApi().instances()
+    request = gce_instance_client.get(
         instance=self.name, project=self.project.project_id, zone=self.zone)
-    return operation
+    response = request.execute()
+    return response
 
   def GetBootDisk(self):
     """Get the virtual machine boot disk.
@@ -867,10 +874,12 @@ class GoogleComputeInstance(GoogleComputeBaseResource):
         'boot': False,
         'autoDelete': False,
     }
-    operation = self.project.GceApi().instances().attachDisk(
+    gce_instance_client = self.project.GceApi().instances()
+    request = gce_instance_client.attachDisk(
         instance=self.name, project=self.project.project_id, zone=self.zone,
-        body=operation_config).execute()
-    self.project.GceOperation(operation, zone=self.zone, block=True)
+        body=operation_config)
+    response = request.execute()
+    self.project.BlockOperation(response, zone=self.zone)
 
 
 class GoogleComputeDisk(GoogleComputeBaseResource):
@@ -882,9 +891,11 @@ class GoogleComputeDisk(GoogleComputeBaseResource):
     Returns:
        str: An API operation object for a Google Compute Engine disk.
     """
-    operation = self.project.GceApi().disks().get(
+    gce_disk_client = self.project.GceApi().disks()
+    request = gce_disk_client.get(
         disk=self.name, project=self.project.project_id, zone=self.zone)
-    return operation
+    response = request.execute()
+    return response
 
   def Snapshot(self, snapshot_name=None):
     """Create Snapshot of the disk.
@@ -911,16 +922,19 @@ class GoogleComputeDisk(GoogleComputeBaseResource):
     truncate_at = 63 - len(timestamp) - 1
     snapshot_name = '{0}-{1}'.format(snapshot_name[:truncate_at], timestamp)
     if not REGEX_DISK_NAME.match(snapshot_name):
-      raise ValueError('Error: Snapshot name {0:s} does not comply with '
-                       '{1:s}'.format(snapshot_name, REGEX_DISK_NAME.pattern))
+      raise ValueError(
+          'Error: Snapshot name {0:s} does not comply with '
+          '{1:s}'.format(snapshot_name, REGEX_DISK_NAME.pattern))
     log.info(
         self.project.FormatLogMessage(
             'New Snapshot: {0}'.format(snapshot_name)))
     operation_config = dict(name=snapshot_name)
-    operation = self.project.GceApi().disks().createSnapshot(
+    gce_disk_client = self.project.GceApi().disks()
+    request = gce_disk_client.createSnapshot(
         disk=self.name, project=self.project.project_id, zone=self.zone,
-        body=operation_config).execute()
-    self.project.GceOperation(operation, zone=self.zone, block=True)
+        body=operation_config)
+    response = request.execute()
+    self.project.BlockOperation(response, zone=self.zone)
     return GoogleComputeSnapshot(disk=self, name=snapshot_name)
 
 
@@ -948,18 +962,22 @@ class GoogleComputeSnapshot(GoogleComputeBaseResource):
     Returns:
        str: An API operation object for a Google Compute Engine Snapshot.
     """
-    operation = self.project.GceApi().snapshots().get(
+    gce_snapshot_client = self.project.GceApi().snapshots()
+    request = gce_snapshot_client.get(
         snapshot=self.name, project=self.project.project_id)
-    return operation
+    response = request.execute()
+    return response
 
   def Delete(self):
     """Delete a Snapshot."""
     log.info(
         self.project.FormatLogMessage(
             'Deleted Snapshot: {0}'.format(self.name)))
-    operation = self.project.GceApi().snapshots().delete(
-        project=self.project.project_id, snapshot=self.name).execute()
-    self.project.GceOperation(operation, block=True)
+    gce_snapshot_client = self.project.GceApi().snapshots()
+    request = gce_snapshot_client.delete(
+        project=self.project.project_id, snapshot=self.name)
+    response = request.execute()
+    self.project.BlockOperation(response)
 
 
 def CreateDiskCopy(src_proj, dst_proj, instance_name, zone, disk_name=None):
@@ -999,13 +1017,14 @@ def CreateDiskCopy(src_proj, dst_proj, instance_name, zone, disk_name=None):
             disk_to_copy.name, new_disk.name))
 
   except AccessTokenRefreshError as exception:
-    error_msg = 'Something is wrong with your gcloud access token: ' \
-                '{0:s}.'.format(exception)
+    error_msg = ('Something is wrong with your gcloud access token: '
+                 '{0:s}.').format(exception)
     raise RuntimeError(error_msg)
   except ApplicationDefaultCredentialsError as exception:
-    error_msg = 'Something is wrong with your Application Default ' \
-                'Credentials. ' \
-                'Try running:\n  $ gcloud auth application-default login'
+    error_msg = (
+        'Something is wrong with your Application Default '
+        'Credentials. '
+        'Try running:\n  $ gcloud auth application-default login')
     raise RuntimeError(error_msg)
   except HttpError as exception:
     if exception.resp.status == 403:
@@ -1091,7 +1110,8 @@ def GenerateDiskName(snapshot, disk_name_prefix=None):
         snapshot.name[:truncate_at], disk_id_crc32)
 
   if not REGEX_DISK_NAME.match(disk_name):
-    raise ValueError('Error: disk name {0:s} does not comply with '
-                     '{1:s}'.format(disk_name, REGEX_DISK_NAME.pattern))
+    raise ValueError(
+        'Error: disk name {0:s} does not comply with '
+        '{1:s}'.format(disk_name, REGEX_DISK_NAME.pattern))
 
   return disk_name

--- a/tests/e2e/gcp_e2e.py
+++ b/tests/e2e/gcp_e2e.py
@@ -52,6 +52,14 @@ class EndToEndTest(unittest.TestCase):
   file: "user@terminal:~$ export PROJECT_INFO='absolute/path/project_info.json'"
   """
 
+  project_id = None
+  instance_to_analyse = None
+  disk_to_forensic = None
+  zone = None
+  gcp = None
+  analysis_vm_name = None
+  analysis_vm = None
+
   @classmethod
   def setUpClass(cls):
     super(EndToEndTest, cls).setUpClass()

--- a/tests/e2e/gcp_e2e.py
+++ b/tests/e2e/gcp_e2e.py
@@ -52,14 +52,6 @@ class EndToEndTest(unittest.TestCase):
   file: "user@terminal:~$ export PROJECT_INFO='absolute/path/project_info.json'"
   """
 
-  project_id = None
-  instance_to_analyse = None
-  disk_to_forensic = None
-  zone = None
-  gcp = None
-  analysis_vm_name = None
-  analysis_vm = None
-
   @classmethod
   def setUpClass(cls):
     super(EndToEndTest, cls).setUpClass()
@@ -192,10 +184,12 @@ class EndToEndTest(unittest.TestCase):
   def tearDownClass(cls):
     super(EndToEndTest, cls).tearDownClass()
 
+    if hasattr(cls, 'error_msg'):
+      raise unittest.SkipTest(cls.error_msg)
+
     analysis_vm = cls.analysis_vm
     zone = cls.zone
     project = cls.gcp
-
     disks = analysis_vm.ListDisks()
     # delete the created forensics VMs
     log.info('Deleting analysis instance: {0:s}.'.format(analysis_vm.name))

--- a/tests/e2e/gcp_e2e.py
+++ b/tests/e2e/gcp_e2e.py
@@ -184,9 +184,9 @@ class EndToEndTest(unittest.TestCase):
   def tearDownClass(cls):
     super(EndToEndTest, cls).tearDownClass()
 
-    analysis_vm = EndToEndTest.analysis_vm
-    zone = EndToEndTest.zone
-    project = EndToEndTest.gcp
+    analysis_vm = cls.analysis_vm
+    zone = cls.zone
+    project = cls.gcp
 
     disks = analysis_vm.ListDisks()
     # delete the created forensics VMs

--- a/tests/e2e/gcp_e2e.py
+++ b/tests/e2e/gcp_e2e.py
@@ -52,27 +52,38 @@ class EndToEndTest(unittest.TestCase):
   file: "user@terminal:~$ export PROJECT_INFO='absolute/path/project_info.json'"
   """
 
-  def __init__(self, *args, **kwargs):
-    super(EndToEndTest, self).__init__(*args, **kwargs)
+  @classmethod
+  def setUpClass(cls):
+    super(EndToEndTest, cls).setUpClass()
     try:
       project_info = ReadProjectInfo()
     except (OSError, RuntimeError, ValueError) as exception:
-      self.error_msg = str(exception)
+      cls.error_msg = str(exception)
       return
-    self.project_id = project_info['project_id']
-    self.instance_to_analyse = project_info['instance']
+    cls.project_id = project_info['project_id']
+    cls.instance_to_analyse = project_info['instance']
     # Optional: test a disk other than the boot disk
-    self.disk_to_forensic = project_info.get('disk', None)
-    self.zone = project_info['zone']
-    self.gcp = gcp.GoogleCloudProject(self.project_id, self.zone)
+    cls.disk_to_forensic = project_info.get('disk', None)
+    cls.zone = project_info['zone']
+    cls.gcp = gcp.GoogleCloudProject(cls.project_id, cls.zone)
+    cls.analysis_vm_name = 'new-vm-for-analysis'
+    # Create and start the analysis VM
+    cls.analysis_vm, _ = gcp.StartAnalysisVm(
+        project=cls.project_id, vm_name=cls.analysis_vm_name, zone=cls.zone,
+        boot_disk_size=10, cpu_cores=4)
 
   def setUp(self):
+    super(EndToEndTest, self).setUp()
     if hasattr(self, 'error_msg'):
       raise unittest.SkipTest(self.error_msg)
+    self.project_id = EndToEndTest.project_id
+    self.instance_to_analyse = EndToEndTest.instance_to_analyse
+    self.disk_to_forensic = EndToEndTest.disk_to_forensic
+    self.gcp = EndToEndTest.gcp
+    self.zone = EndToEndTest.zone
+    self.analysis_vm_name = EndToEndTest.analysis_vm.name
     self.boot_disk_copy = None
     self.disk_to_forensic_copy = None
-    self.analysis_vm = None
-    self.analysis_vm_name = 'new-vm-for-analysis'
 
   def test_end_to_end_boot_disk(self):
     """End to end test on GCP.
@@ -96,38 +107,31 @@ class EndToEndTest(unittest.TestCase):
     )
 
     # The disk copy should be attached to the analysis project
-    operation = self.gcp.GceApi().disks().get(
-        project=self.project_id,
-        zone=self.zone,
-        disk=self.boot_disk_copy.name).execute()
-    result = self.gcp.GceOperation(operation, zone=self.zone)
+    gce_disk_client = self.gcp.GceApi().disks()
+    request = gce_disk_client.get(
+        project=self.project_id, zone=self.zone, disk=self.boot_disk_copy.name)
+    result = request.execute()
     self.assertEqual(result['name'], self.boot_disk_copy.name)
 
-    # Create and start the analysis VM and attach the boot disk
+    # Get the analysis VM and attach the evidence boot disk
     self.analysis_vm, _ = gcp.StartAnalysisVm(
-        project=self.project_id,
-        vm_name=self.analysis_vm_name,
-        zone=self.zone,
-        boot_disk_size=10,
-        cpu_cores=4,
-        attach_disk=self.boot_disk_copy
-    )
+        project=self.project_id, vm_name=self.analysis_vm_name, zone=self.zone,
+        boot_disk_size=10, cpu_cores=4, attach_disk=self.boot_disk_copy)
 
     # The forensic instance should be live in the analysis GCP project and
     # the disk should be attached
-    operation = self.gcp.GceApi().instances().get(
-        project=self.project_id,
-        zone=self.zone,
-        instance=self.analysis_vm_name).execute()
-    result = self.gcp.GceOperation(operation, zone=self.zone)
+    gce_instance_client = self.gcp.GceApi().instances()
+    request = gce_instance_client.get(
+        project=self.project_id, zone=self.zone, instance=self.analysis_vm_name)
+    result = request.execute()
     self.assertEqual(result['name'], self.analysis_vm_name)
 
     for disk in result['disks']:
-      if disk['source'].split("/")[-1] == self.boot_disk_copy.name:
+      if disk['source'].split('/')[-1] == self.boot_disk_copy.name:
         return
-    self.fail('Error: could not find the disk {0:s} in instance {1:s}'.format(
-        self.boot_disk_copy.name, self.analysis_vm_name
-    ))
+    self.fail(
+        'Error: could not find the disk {0:s} in instance {1:s}'.format(
+            self.boot_disk_copy.name, self.analysis_vm_name))
 
   def test_end_to_end_other_disk(self):
     """End to end test on GCP.
@@ -144,71 +148,62 @@ class EndToEndTest(unittest.TestCase):
 
     # Make a copy of another disk of the instance to analyse
     self.disk_to_forensic_copy = gcp.CreateDiskCopy(
-        src_proj=self.project_id,
-        dst_proj=self.project_id,
-        instance_name=self.instance_to_analyse,
-        zone=self.zone,
-        disk_name=self.disk_to_forensic
-    )
+        src_proj=self.project_id, dst_proj=self.project_id,
+        instance_name=self.instance_to_analyse, zone=self.zone,
+        disk_name=self.disk_to_forensic)
 
-    # The disk copy should be attached to the analysis project
-    operation = self.gcp.GceApi().disks().get(
-        project=self.project_id,
-        zone=self.zone,
-        disk=self.disk_to_forensic_copy.name).execute()
-    result = self.gcp.GceOperation(operation, zone=self.zone)
+    # The disk copy should be existing in the analysis project
+    gce_disk_client = self.gcp.GceApi().disks()
+    request = gce_disk_client.get(
+        project=self.project_id, zone=self.zone,
+        disk=self.disk_to_forensic_copy.name)
+    result = request.execute()
     self.assertEqual(result['name'], self.disk_to_forensic_copy.name)
 
-    # Create and start the analysis VM and attach the disk to forensic
+    # Get the analysis VM and attach the evidence disk to forensic
     self.analysis_vm, _ = gcp.StartAnalysisVm(
-        project=self.project_id,
-        vm_name=self.analysis_vm_name,
-        zone=self.zone,
-        boot_disk_size=10,
-        cpu_cores=4,
-        attach_disk=self.disk_to_forensic_copy
-    )
+        project=self.project_id, vm_name=self.analysis_vm_name, zone=self.zone,
+        boot_disk_size=10, cpu_cores=4, attach_disk=self.disk_to_forensic_copy)
 
     # The forensic instance should be live in the analysis GCP project and
     # the disk should be attached
-    operation = self.gcp.GceApi().instances().get(
-        project=self.project_id,
-        zone=self.zone,
-        instance=self.analysis_vm_name).execute()
-    result = self.gcp.GceOperation(operation, zone=self.zone)
+    gce_instance_client = self.gcp.GceApi().instances()
+    request = gce_instance_client.get(
+        project=self.project_id, zone=self.zone, instance=self.analysis_vm_name)
+    result = request.execute()
     self.assertEqual(result['name'], self.analysis_vm_name)
 
     for disk in result['disks']:
-      if disk['source'].split("/")[-1] == self.disk_to_forensic_copy.name:
+      if disk['source'].split('/')[-1] == self.disk_to_forensic_copy.name:
         return
-    self.fail('Error: could not find the disk {0:s} in instance {1:s}'.format(
-        self.disk_to_forensic_copy.name, self.analysis_vm_name
-    ))
+    self.fail(
+        'Error: could not find the disk {0:s} in instance {1:s}'.format(
+            self.disk_to_forensic_copy.name, self.analysis_vm_name))
 
-  def tearDown(self):
-    project = gcp.GoogleCloudProject(project_id=self.project_id,
-                                     default_zone=self.zone)
+  @classmethod
+  def tearDownClass(cls):
+    super(EndToEndTest, cls).tearDownClass()
 
-    disks = self.analysis_vm.ListDisks()
+    analysis_vm = EndToEndTest.analysis_vm
+    zone = EndToEndTest.zone
+    project = EndToEndTest.gcp
 
+    disks = analysis_vm.ListDisks()
     # delete the created forensics VMs
-    log.info('Deleting analysis instance: {0:s}.'.format(
-        self.analysis_vm.name))
-    operation = project.GceApi().instances().delete(
-        project=project.project_id,
-        zone=self.zone,
-        instance=self.analysis_vm.name
-    ).execute()
+    log.info('Deleting analysis instance: {0:s}.'.format(analysis_vm.name))
+    gce_instance_client = project.GceApi().instances()
+    request = gce_instance_client.delete(
+        project=project.project_id, zone=zone, instance=analysis_vm.name)
+    response = request.execute()
     try:
-      project.GceOperation(operation, block=True)
+      project.BlockOperation(response)
     except HttpError:
-      # GceOperation triggers a while(True) loop that checks on the
+      # BlockOperation triggers a while(True) loop that checks on the
       # operation ID. Sometimes it loops one more time right when the
       # operation has finished and thus the associated ID doesn't exists
       # anymore, throwing an HttpError. We can ignore this.
       pass
-    log.info('Instance {0:s} successfully deleted.'.format(
-        self.analysis_vm.name))
+    log.info('Instance {0:s} successfully deleted.'.format(analysis_vm.name))
 
     # delete the copied disks
     # we ignore the disk that was created for the analysis VM (disks[0]) as
@@ -217,12 +212,11 @@ class EndToEndTest(unittest.TestCase):
       log.info('Deleting disk: {0:s}.'.format(disk))
       while True:
         try:
-          operation = project.GceApi().disks().delete(
-              project=project.project_id,
-              zone=self.zone,
-              disk=disk
-          ).execute()
-          project.GceOperation(operation, block=True)
+          gce_disk_client = project.GceApi().disks()
+          request = gce_disk_client.delete(
+              project=project.project_id, zone=zone, disk=disk)
+          response = request.execute()
+          project.BlockOperation(response)
           break
         except HttpError as exception:
           # The gce api will throw a 400 until the analysis vm's deletion is
@@ -231,18 +225,17 @@ class EndToEndTest(unittest.TestCase):
           if exception.resp.status == 404:
             break
           if exception.resp.status != 400:
-            log.warning('Could not delete the disk {0:s}: {1:s}'.format(
-                disk, str(exception)
-            ))
+            log.warning(
+                'Could not delete the disk {0:s}: {1:s}'.format(
+                    disk, str(exception)))
           # Throttle the requests to one every 10 seconds
           time.sleep(10)
 
-      log.info('Disk {0:s} successfully deleted.'.format(
-          disk))
+      log.info('Disk {0:s} successfully deleted.'.format(disk))
 
 
 def ReadProjectInfo():
-  """ Read project information to run e2e test.
+  """Read project information to run e2e test.
 
   Returns:
     dict: A dict with the project information.
@@ -254,28 +247,29 @@ def ReadProjectInfo():
   """
   project_info = os.environ.get('PROJECT_INFO')
   if project_info is None:
-    raise OSError('Error: please make sure that you defined the '
-                  '"PROJECT_INFO" environment variable pointing '
-                  'to your project settings.')
+    raise OSError(
+        'Error: please make sure that you defined the '
+        '"PROJECT_INFO" environment variable pointing '
+        'to your project settings.')
   try:
     json_file = open(project_info)
     try:
       project_info = json.load(json_file)
     except ValueError as exception:
-      raise RuntimeError('Error: cannot parse JSON file. {0:s}'.format(
-          str(exception)))
+      raise RuntimeError(
+          'Error: cannot parse JSON file. {0:s}'.format(str(exception)))
     json_file.close()
   except OSError as exception:
-    raise OSError('Error: could not open/close file {0:s}: {1:s}'.format(
-        project_info, str(exception)
-    ))
+    raise OSError(
+        'Error: could not open/close file {0:s}: {1:s}'.format(
+            project_info, str(exception)))
 
-  if not all(key in project_info for key in ['project_id', 'instance',
-                                             'zone']):
-    raise ValueError('Error: please make sure that your JSON file '
-                     'has the required entries. The file should '
-                     'contain at least the following: ["project_id", '
-                     '"instance", "zone"].')
+  if not all(key in project_info for key in ['project_id', 'instance', 'zone']):
+    raise ValueError(
+        'Error: please make sure that your JSON file '
+        'has the required entries. The file should '
+        'contain at least the following: ["project_id", '
+        '"instance", "zone"].')
 
   return project_info
 

--- a/tests/unittest/gcp_test.py
+++ b/tests/unittest/gcp_test.py
@@ -29,48 +29,23 @@ from libcloudforensics import gcp
 
 # For the forensics analysis
 FAKE_ANALYSIS_PROJECT = gcp.GoogleCloudProject(
-    'fake-target-project',
-    'fake-zone'
-)
+    'fake-target-project', 'fake-zone')
 FAKE_ANALYSIS_VM = gcp.GoogleComputeInstance(
-    FAKE_ANALYSIS_PROJECT,
-    'fake-zone',
-    'fake-analysis-vm'
-)
+    FAKE_ANALYSIS_PROJECT, 'fake-zone', 'fake-analysis-vm')
 
 # Source project with the instance that needs forensicating
-FAKE_SOURCE_PROJECT = gcp.GoogleCloudProject(
-    'fake-source-project',
-    'fake-zone'
-)
+FAKE_SOURCE_PROJECT = gcp.GoogleCloudProject('fake-source-project', 'fake-zone')
 FAKE_INSTANCE = gcp.GoogleComputeInstance(
-    FAKE_SOURCE_PROJECT,
-    'fake-zone',
-    'fake-instance'
-)
-FAKE_DISK = gcp.GoogleComputeDisk(
-    FAKE_SOURCE_PROJECT,
-    'fake-zone',
-    'fake-disk'
-)
+    FAKE_SOURCE_PROJECT, 'fake-zone', 'fake-instance')
+FAKE_DISK = gcp.GoogleComputeDisk(FAKE_SOURCE_PROJECT, 'fake-zone', 'fake-disk')
 FAKE_BOOT_DISK = gcp.GoogleComputeDisk(
-    FAKE_SOURCE_PROJECT,
-    'fake-zone',
-    'fake-boot-disk'
-)
-FAKE_SNAPSHOT = gcp.GoogleComputeSnapshot(
-    FAKE_DISK,
-    'fake-snapshot'
-)
+    FAKE_SOURCE_PROJECT, 'fake-zone', 'fake-boot-disk')
+FAKE_SNAPSHOT = gcp.GoogleComputeSnapshot(FAKE_DISK, 'fake-snapshot')
 FAKE_SNAPSHOT_LONG_NAME = gcp.GoogleComputeSnapshot(
     FAKE_DISK,
-    'this-is-a-kind-of-long-fake-snapshot-name-and-is-definitely-over-63-chars'
-)
+    'this-is-a-kind-of-long-fake-snapshot-name-and-is-definitely-over-63-chars')
 FAKE_DISK_COPY = gcp.GoogleComputeDisk(
-    FAKE_SOURCE_PROJECT,
-    'fake-zone',
-    'fake-disk-copy'
-)
+    FAKE_SOURCE_PROJECT, 'fake-zone', 'fake-disk-copy')
 
 # Mock struct to mimic GCP's API responses
 MOCK_INSTANCES_AGGREGATED = {
@@ -78,12 +53,10 @@ MOCK_INSTANCES_AGGREGATED = {
     # /aggregatedList for complete structure
     'items': {
         0: {
-            'instances': [
-                {
-                    'name': FAKE_INSTANCE.name,
-                    'zone': '/' + FAKE_INSTANCE.zone
-                }
-            ]
+            'instances': [{
+                'name': FAKE_INSTANCE.name,
+                'zone': '/' + FAKE_INSTANCE.zone
+            }]
         }
     }
 }
@@ -93,29 +66,21 @@ MOCK_DISKS_AGGREGATED = {
     # /aggregatedList for complete structure
     'items': {
         0: {
-            'disks': [
-                {
-                    'name': FAKE_BOOT_DISK.name,
-                    'zone': '/' + FAKE_BOOT_DISK.zone
-                }
-            ]
+            'disks': [{
+                'name': FAKE_BOOT_DISK.name,
+                'zone': '/' + FAKE_BOOT_DISK.zone
+            }]
         },
         1: {
-            'disks': [
-                {
-                    'name': FAKE_DISK.name,
-                    'zone': '/' + FAKE_DISK.zone
-                }
-            ]
+            'disks': [{
+                'name': FAKE_DISK.name,
+                'zone': '/' + FAKE_DISK.zone
+            }]
         }
     }
 }
 
-MOCK_LIST_INSTANCES = {
-    FAKE_INSTANCE.name: {
-        'zone': FAKE_INSTANCE.zone
-    }
-}
+MOCK_LIST_INSTANCES = {FAKE_INSTANCE.name: {'zone': FAKE_INSTANCE.zone}}
 
 MOCK_LIST_DISKS = {
     FAKE_DISK.name: {
@@ -128,37 +93,32 @@ MOCK_LIST_DISKS = {
 
 MOCK_GCE_OPERATION_INSTANCES_LABELS_SUCCESS = {
     'items': {
-        '/zone': {
-            'instances': [
-                {
-                    'name': FAKE_INSTANCE.name,
-                    'zone': '/' + FAKE_INSTANCE.zone,
-                    'labels': {
-                        'id': '123'
-                    }
+        'zone': {
+            'instances': [{
+                'name': FAKE_INSTANCE.name,
+                'zone': '/' + FAKE_INSTANCE.zone,
+                'labels': {
+                    'id': '123'
                 }
-            ]
+            }]
         }
     }
 }
 
 MOCK_GCE_OPERATION_DISKS_LABELS_SUCCESS = {
     'items': {
-        '/zone': {
-            'disks': [
-                {
-                    'name': FAKE_DISK.name,
-                    'labels': {
-                        'id': '123'
-                    }
-                },
-                {
-                    'name': FAKE_BOOT_DISK.name,
-                    'labels': {
-                        'some': 'thing'
-                    }
+        'zone': {
+            'disks': [{
+                'name': FAKE_DISK.name,
+                'labels': {
+                    'id': '123'
                 }
-            ]
+            }, {
+                'name': FAKE_BOOT_DISK.name,
+                'labels': {
+                    'some': 'thing'
+                }
+            }]
         }
     }
 }
@@ -174,20 +134,18 @@ MOCK_GCE_OPERATION_LABELS_FAILED = {
 MOCK_GCE_OPERATION_INSTANCES_GET = {
     # See https://cloud.google.com/compute/docs/reference/rest/v1/instances/get
     # for complete structure
-    'name': FAKE_INSTANCE.name,
-    'disks': [
-        {
-            'boot': True,
-            'source': '/' + FAKE_BOOT_DISK.name,
-        },
-        {
-            'boot': False,
-            'source': '/' + FAKE_DISK.name,
-            'initializeParams': {
-                'diskName': FAKE_DISK.name
-            }
+    'name':
+        FAKE_INSTANCE.name,
+    'disks': [{
+        'boot': True,
+        'source': '/' + FAKE_BOOT_DISK.name,
+    }, {
+        'boot': False,
+        'source': '/' + FAKE_DISK.name,
+        'initializeParams': {
+            'diskName': FAKE_DISK.name
         }
-    ]
+    }]
 }
 
 # See: https://cloud.google.com/compute/docs/reference/rest/v1/disks
@@ -204,29 +162,24 @@ class GoogleCloudProjectTest(unittest.TestCase):
     formatted_msg = FAKE_ANALYSIS_PROJECT.FormatLogMessage(msg)
     self.assertIsInstance(formatted_msg, six.string_types)
     self.assertEqual(
-        formatted_msg,
-        'project:{0:s} {1:s}'.format(FAKE_ANALYSIS_PROJECT.project_id, msg)
-    )
+        formatted_msg, 'project:{0:s} {1:s}'.format(
+            FAKE_ANALYSIS_PROJECT.project_id, msg))
 
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testListInstances(self, mock_gce_api, mock_gce_operation):
+  def testListInstances(self, mock_gce_api):
     """Test that instances of project are correctly listed."""
     mock_gce_api.return_value.instances.return_value.aggregatedList \
-      .return_value.execute.return_value = None
-    mock_gce_operation.return_value = MOCK_INSTANCES_AGGREGATED
+      .return_value.execute.return_value = MOCK_INSTANCES_AGGREGATED
     instances = FAKE_ANALYSIS_PROJECT.ListInstances()
     self.assertEqual(len(instances), 1)
-    self.assertTrue('fake-instance' in instances)
+    self.assertIn('fake-instance', instances)
     self.assertEqual(instances['fake-instance']['zone'], 'fake-zone')
 
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testListDisks(self, mock_gce_api, mock_gce_operation):
+  def testListDisks(self, mock_gce_api):
     """Test that disks of instances are correctly listed."""
     mock_gce_api.return_value.disks.return_value.aggregatedList.return_value \
-      .execute.return_value = None
-    mock_gce_operation.return_value = MOCK_DISKS_AGGREGATED
+      .execute.return_value = MOCK_DISKS_AGGREGATED
     disks = FAKE_ANALYSIS_PROJECT.ListDisks()
     self.assertEqual(len(disks), 2)
     self.assertTrue('fake-disk' in disks and 'fake-boot-disk' in disks)
@@ -260,61 +213,45 @@ class GoogleCloudProjectTest(unittest.TestCase):
     self.assertRaises(
         RuntimeError, FAKE_SOURCE_PROJECT.GetDisk, 'non-existent-disk')
 
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.BlockOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testCreateDiskFromSnapshot(self, mock_gce_api, mock_gce_operation):
+  def testCreateDiskFromSnapshot(self, mock_gce_api, mock_block_operation):
     """Test the creation of a disk from a Snapshot."""
+    mock_block_operation.return_value = None
     mock_gce_api.return_value.disks.return_value.insert.return_value.execute \
       .return_value = None
-    mock_gce_operation.return_value = None
 
     # CreateDiskFromSnapshot(Snapshot=FAKE_SNAPSHOT, disk_name=None,
     # disk_name_prefix='')
     disk_from_snapshot = FAKE_ANALYSIS_PROJECT.CreateDiskFromSnapshot(
         FAKE_SNAPSHOT)
-    self.assertIsInstance(
-        disk_from_snapshot, gcp.GoogleComputeDisk)
+    self.assertIsInstance(disk_from_snapshot, gcp.GoogleComputeDisk)
     self.assertEqual(
-        disk_from_snapshot.name, gcp.GenerateDiskName(
-            FAKE_SNAPSHOT))
+        disk_from_snapshot.name, gcp.GenerateDiskName(FAKE_SNAPSHOT))
 
     # CreateDiskFromSnapshot(Snapshot=FAKE_SNAPSHOT,
     # disk_name='new-forensics-disk', disk_name_prefix='')
     disk_from_snapshot = FAKE_ANALYSIS_PROJECT.CreateDiskFromSnapshot(
-        FAKE_SNAPSHOT,
-        disk_name='new-forensics-disk'
-    )
+        FAKE_SNAPSHOT, disk_name='new-forensics-disk')
     self.assertIsInstance(disk_from_snapshot, gcp.GoogleComputeDisk)
-    self.assertEqual(
-        disk_from_snapshot.name,
-        'new-forensics-disk'
-    )
+    self.assertEqual(disk_from_snapshot.name, 'new-forensics-disk')
 
     # CreateDiskFromSnapshot(Snapshot=FAKE_SNAPSHOT, disk_name=None,
     # disk_name_prefix='prefix')
     disk_from_snapshot = FAKE_ANALYSIS_PROJECT.CreateDiskFromSnapshot(
-        FAKE_SNAPSHOT,
-        disk_name_prefix='prefix'
-    )
+        FAKE_SNAPSHOT, disk_name_prefix='prefix')
     self.assertIsInstance(disk_from_snapshot, gcp.GoogleComputeDisk)
     self.assertEqual(
         disk_from_snapshot.name,
-        gcp.GenerateDiskName(
-            FAKE_SNAPSHOT, disk_name_prefix='prefix')
-    )
+        gcp.GenerateDiskName(FAKE_SNAPSHOT, disk_name_prefix='prefix'))
 
     # CreateDiskFromSnapshot(Snapshot=FAKE_SNAPSHOT,
     # disk_name='new-forensics-disk', disk_name_prefix='prefix')
     disk_from_snapshot = FAKE_ANALYSIS_PROJECT.CreateDiskFromSnapshot(
-        FAKE_SNAPSHOT,
-        disk_name='new-forensics-disk',
-        disk_name_prefix='prefix'
-    )
+        FAKE_SNAPSHOT, disk_name='new-forensics-disk',
+        disk_name_prefix='prefix')
     self.assertIsInstance(disk_from_snapshot, gcp.GoogleComputeDisk)
-    self.assertEqual(
-        disk_from_snapshot.name,
-        'new-forensics-disk'
-    )
+    self.assertEqual(disk_from_snapshot.name, 'new-forensics-disk')
 
     # CreateDiskFromSnapshot(Snapshot=FAKE_SNAPSHOT,
     # disk_name='fake-disk') where 'fake-disk' exists already
@@ -326,9 +263,8 @@ class GoogleCloudProjectTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as context:
       _ = FAKE_ANALYSIS_PROJECT.CreateDiskFromSnapshot(
           FAKE_SNAPSHOT, disk_name=FAKE_DISK.name)
-    self.assertEqual(str(context.exception), 'Disk {0:s} already exists'.format(
-        'fake-disk'
-    ))
+    self.assertEqual(
+        str(context.exception), 'Disk {0:s} already exists'.format('fake-disk'))
 
     # other network issue should fail the disk creation
     mock_gce_api.return_value.disks.return_value.insert.return_value.execute \
@@ -339,20 +275,20 @@ class GoogleCloudProjectTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as context:
       _ = FAKE_ANALYSIS_PROJECT.CreateDiskFromSnapshot(
           FAKE_SNAPSHOT, FAKE_DISK.name)
-    self.assertTrue('status: 418' in str(context.exception))
+    self.assertIn('status: 418', str(context.exception))
 
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GetInstance')
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.BlockOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testGetOrCreateAnalysisVm(self, mock_gce_api,
-                                mock_gce_operation, mock_get_instance):
+  def testGetOrCreateAnalysisVm(
+      self, mock_gce_api, mock_block_operation, mock_get_instance):
     """Test that a new virtual machine is created if it doesn't exist,
     or that the existing one is returned. """
     mock_gce_api.return_value.images.return_value.getFromFamily.return_value \
-      .execute.return_value = None
+      .execute.return_value = {'selfLink': 'value'}
+    mock_block_operation.return_value = None
     mock_gce_api.return_value.instances.return_value.insert.return_value \
       .execute.return_value = None
-    mock_gce_operation.return_value = None
     mock_get_instance.return_value = FAKE_ANALYSIS_VM
 
     # GetOrCreateAnalysisVm(existing_vm, boot_disk_size)
@@ -366,59 +302,74 @@ class GoogleCloudProjectTest(unittest.TestCase):
     # GetInstance() call to throw a runtime error to mimic an instance that
     # wasn't found
     mock_get_instance.side_effect = RuntimeError()
-    mock_gce_operation.return_value = {
-        'selfLink': 'value'
-    }
     vm, created = FAKE_ANALYSIS_PROJECT.GetOrCreateAnalysisVm(
         'non-existent-analysis-vm', boot_disk_size=1)
     self.assertIsInstance(vm, gcp.GoogleComputeInstance)
     self.assertEqual(vm.name, 'non-existent-analysis-vm')
     self.assertTrue(created)
 
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.ListInstanceByLabels')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testListInstanceByLabels(self, mock_gce_api, mock_gce_operation):
+  def testListInstanceByLabels(
+      self, mock_gce_api, mock_list_instance_by_labels):
     """Test that instances are correctly listed when searching with a filter."""
-    mock_gce_api.return_value.instances.return_value.aggregatedList \
-      .return_value.execute.return_value = None
-    # To exit the loop
-    mock_gce_api.return_value.instances.return_value.aggregatedList_next \
-      .return_value = None
-    # Labels found, GCE API will return instances
-    mock_gce_operation.return_value = \
-      MOCK_GCE_OPERATION_INSTANCES_LABELS_SUCCESS
+    mock_gce_api.return_value.instances.return_value = None
+    mock_list_instance_by_labels.return_value = \
+        MOCK_GCE_OPERATION_INSTANCES_LABELS_SUCCESS
     instances = FAKE_ANALYSIS_PROJECT.ListInstanceByLabels(
         labels_filter={'id': '123'})
-    self.assertEqual(len(instances), 1)
-    self.assertTrue(FAKE_INSTANCE.name in instances)
+    if 'zone' in instances['items']:
+      instance_names = [
+          instance['name']
+          for instance in instances['items']['zone']['instances']
+      ]
+    else:
+      instance_names = []
+    self.assertEqual(len(instance_names), 1)
+    self.assertIn(FAKE_INSTANCE.name, instance_names)
 
     # Labels not found, GCE API will return no items
-    mock_gce_operation.return_value = MOCK_GCE_OPERATION_LABELS_FAILED
+    mock_list_instance_by_labels.return_value = MOCK_GCE_OPERATION_LABELS_FAILED
     instances = FAKE_ANALYSIS_PROJECT.ListInstanceByLabels(
         labels_filter={'id': '123'})
-    self.assertEqual(len(instances), 0)
+    if 'zone' in instances['items']:
+      instance_names = [
+          instance['name']
+          for instance in instances['items']['zone']['instances']
+      ]
+    else:
+      instance_names = []
+    self.assertEqual(len(instance_names), 0)
 
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.ListDiskByLabels')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testListDisksByLabels(self, mock_gce_api, mock_gce_operation):
+  def testListDisksByLabels(self, mock_gce_api, mock_list_disk_by_labels):
     """Test that disks are correctly listed when searching with a filter."""
-    mock_gce_api.return_value.disks.return_value.aggregatedList.return_value \
-      .execute.return_value = None
-    # To exit the loop
-    mock_gce_api.return_value.disks.return_value.aggregatedList_next \
-      .return_value = None
+    mock_gce_api.return_value.disks.return_value = None
+    mock_list_disk_by_labels.return_value = \
+        MOCK_GCE_OPERATION_DISKS_LABELS_SUCCESS
     # Labels found, GCE API will return disks
-    mock_gce_operation.return_value = MOCK_GCE_OPERATION_DISKS_LABELS_SUCCESS
     disks = FAKE_ANALYSIS_PROJECT.ListDiskByLabels(
-        labels_filter={'id': '123', 'some': 'thing'})
-    self.assertEqual(len(disks), 2)
-    self.assertTrue('fake-disk' in disks and 'fake-boot-disk' in disks)
+        labels_filter={
+            'id': '123',
+            'some': 'thing'
+        })
+    if 'zone' in disks['items']:
+      disk_names = [disk['name'] for disk in disks['items']['zone']['disks']]
+    else:
+      disk_names = []
+    self.assertEqual(len(disk_names), 2)
+    self.assertTrue(
+        'fake-disk' in disk_names and 'fake-boot-disk' in disk_names)
 
     # Labels not found, GCE API will return no items
-    mock_gce_operation.return_value = MOCK_GCE_OPERATION_LABELS_FAILED
-    instances = FAKE_ANALYSIS_PROJECT.ListDiskByLabels(
-        labels_filter={'id': '123'})
-    self.assertEqual(len(instances), 0)
+    mock_list_disk_by_labels.return_value = MOCK_GCE_OPERATION_LABELS_FAILED
+    disks = FAKE_ANALYSIS_PROJECT.ListDiskByLabels(labels_filter={'id': '123'})
+    if 'zone' in disks['items']:
+      disk_names = [disk['name'] for disk in disks['items']['zone']['disks']]
+    else:
+      disk_names = []
+    self.assertEqual(len(disk_names), 0)
 
   def testReadStartupScript(self):
     """Test that the startup script is correctly read."""
@@ -429,8 +380,8 @@ class GoogleCloudProjectTest(unittest.TestCase):
     self.assertTrue(script.endswith('(exit ${exit_code})\n'))
 
     # Environment variable set to custom script
-    os.environ['STARTUP_SCRIPT'] = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), STARTUP_SCRIPT)
+    os.environ['STARTUP_SCRIPT'] = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), STARTUP_SCRIPT)
     script = FAKE_SOURCE_PROJECT._ReadStartupScript()
     self.assertEqual('# THIS IS A CUSTOM BASH SCRIPT', script)
 
@@ -446,7 +397,7 @@ class GoogleComputeBaseResourceTest(unittest.TestCase):
   @mock.patch('libcloudforensics.gcp.GoogleComputeInstance.GetOperation')
   def testGetValue(self, mock_get_operation):
     """Test that the correct value is retrieved for the given key."""
-    mock_get_operation.return_value.execute.return_value = {
+    mock_get_operation.return_value = {
         # See https://cloud.google.com/compute/docs/reference/rest/v1/instances
         # /get for complete structure
         'name': FAKE_INSTANCE.name
@@ -462,7 +413,7 @@ class GoogleComputeInstanceTest(unittest.TestCase):
   @mock.patch('libcloudforensics.gcp.GoogleComputeInstance.GetOperation')
   def testGetBootDisk(self, mock_get_operation, mock_list_disks):
     """Test that a boot disk is retrieved if existing."""
-    mock_get_operation.return_value.execute.return_value = \
+    mock_get_operation.return_value = \
       MOCK_GCE_OPERATION_INSTANCES_GET
     mock_list_disks.return_value = MOCK_LIST_DISKS
 
@@ -474,7 +425,7 @@ class GoogleComputeInstanceTest(unittest.TestCase):
   @mock.patch('libcloudforensics.gcp.GoogleComputeInstance.GetOperation')
   def testGetDisk(self, mock_get_operation, mock_list_disks):
     """Test that a disk is retrieved by its name, if existing."""
-    mock_get_operation.return_value.execute.return_value = \
+    mock_get_operation.return_value = \
       MOCK_GCE_OPERATION_INSTANCES_GET
     mock_list_disks.return_value = MOCK_LIST_DISKS
 
@@ -495,7 +446,7 @@ class GoogleComputeInstanceTest(unittest.TestCase):
   @mock.patch('libcloudforensics.gcp.GoogleComputeInstance.GetOperation')
   def testListDisks(self, mock_get_operation, mock_list_disks):
     """Test that a all disks of an instance are correctly retrieved."""
-    mock_get_operation.return_value.execute.return_value = \
+    mock_get_operation.return_value = \
       MOCK_GCE_OPERATION_INSTANCES_GET
     mock_list_disks.return_value = MOCK_LIST_DISKS
 
@@ -507,13 +458,13 @@ class GoogleComputeInstanceTest(unittest.TestCase):
 class GoogleComputeDiskTest(unittest.TestCase):
   """Test Google Cloud Compute Disk class."""
 
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.BlockOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
-  def testSnapshot(self, mock_gce_operation, mock_gce_api):
+  def testSnapshot(self, mock_gce_api, mock_block_operation):
     """Test that a Snapshot of the disk is created."""
-    mock_gce_operation.return_value = None
     mock_gce_api.return_value.disks.return_value.createSnapshot.return_value \
       .execute.return_value = None
+    mock_block_operation.return_value = None
 
     # Snapshot(snapshot_name=None). Snapshot should start with the disk's name
     snapshot = FAKE_DISK.Snapshot()
@@ -533,86 +484,77 @@ class GoogleComputeDiskTest(unittest.TestCase):
 class GCPTest(unittest.TestCase):
   """Test the gcp.py public methods."""
 
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.BlockOperation')
   @mock.patch('libcloudforensics.gcp.GoogleComputeInstance.GetBootDisk')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GetInstance')
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testCreateDiskCopy1(self, mock_gce_api, mock_gce_operation,
-                          mock_get_instance, mock_get_boot_disk):
+  def testCreateDiskCopy1(
+      self, mock_gce_api, mock_get_instance, mock_get_boot_disk,
+      mock_block_operation):
     """Test that a disk from a remote project is duplicated and attached to
     an analysis project. """
     mock_gce_api.return_value.instances.return_value.aggregatedList \
-      .return_value.execute.return_value = None
-    mock_gce_operation.return_value = MOCK_INSTANCES_AGGREGATED
+      .return_value.execute.return_value = MOCK_INSTANCES_AGGREGATED
     mock_get_instance.return_value = FAKE_INSTANCE
     mock_get_boot_disk.return_value = FAKE_BOOT_DISK
+    mock_block_operation.return_value = None
 
     # create_disk_copy(src_proj, dst_proj, instance_name='fake-instance',
     # zone='fake-zone', disk_name=None) Should grab the boot disk
-    new_disk = gcp.CreateDiskCopy(FAKE_SOURCE_PROJECT.project_id,
-                                  FAKE_ANALYSIS_PROJECT.project_id,
-                                  instance_name=FAKE_INSTANCE.name,
-                                  zone=FAKE_INSTANCE.zone,
-                                  disk_name=None)
+    new_disk = gcp.CreateDiskCopy(
+        FAKE_SOURCE_PROJECT.project_id, FAKE_ANALYSIS_PROJECT.project_id,
+        instance_name=FAKE_INSTANCE.name, zone=FAKE_INSTANCE.zone,
+        disk_name=None)
     self.assertIsInstance(new_disk, gcp.GoogleComputeDisk)
     self.assertTrue(new_disk.name.startswith('evidence-'))
-    self.assertTrue('fake-boot-disk' in new_disk.name)
+    self.assertIn('fake-boot-disk', new_disk.name)
     self.assertTrue(new_disk.name.endswith('-copy'))
 
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.BlockOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GetDisk')
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
   @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testCreateDiskCopy2(self, mock_gce_api, mock_gce_operation,
-                          mock_get_disk):
+  def testCreateDiskCopy2(
+      self, mock_gce_api, mock_get_disk, mock_block_operation):
     """Test that a disk from a remote project is duplicated and attached to
     an analysis project. """
     mock_gce_api.return_value.instances.return_value.aggregatedList \
-      .return_value.execute.return_value = None
-    mock_gce_operation.return_value = MOCK_INSTANCES_AGGREGATED
+      .return_value.execute.return_value = MOCK_INSTANCES_AGGREGATED
     mock_get_disk.return_value = FAKE_DISK
+    mock_block_operation.return_value = None
 
     # create_disk_copy(src_proj, dst_proj, instance_name=None,
     # zone='fake-zone', disk_name='fake-disk') Should grab 'fake-disk'
-    new_disk = gcp.CreateDiskCopy(FAKE_SOURCE_PROJECT.project_id,
-                                  FAKE_ANALYSIS_PROJECT.project_id,
-                                  instance_name=None,
-                                  zone=FAKE_INSTANCE.zone,
-                                  disk_name=FAKE_DISK.name)
+    new_disk = gcp.CreateDiskCopy(
+        FAKE_SOURCE_PROJECT.project_id, FAKE_ANALYSIS_PROJECT.project_id,
+        instance_name=None, zone=FAKE_INSTANCE.zone, disk_name=FAKE_DISK.name)
     self.assertIsInstance(new_disk, gcp.GoogleComputeDisk)
     self.assertTrue(new_disk.name.startswith('evidence-'))
-    self.assertTrue('fake-disk' in new_disk.name)
+    self.assertIn('fake-disk', new_disk.name)
     self.assertTrue(new_disk.name.endswith('-copy'))
 
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceOperation')
-  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.GceApi')
-  def testCreateDiskCopy3(self, mock_gce_api, mock_gce_operation):
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.ListInstances')
+  @mock.patch('libcloudforensics.gcp.GoogleCloudProject.ListDisks')
+  def testCreateDiskCopy3(self, mock_list_disks, mock_list_instances):
     """Test that a disk from a remote project is duplicated and attached to
     an analysis project. """
-    mock_gce_api.return_value.instances.return_value.aggregatedList \
-      .return_value.execute.return_value = None
-    mock_gce_operation.return_value = MOCK_INSTANCES_AGGREGATED
+    mock_list_disks.return_value = MOCK_DISKS_AGGREGATED
+    mock_list_instances.return_value = MOCK_INSTANCES_AGGREGATED
 
     # create_disk_copy(src_proj, dst_proj, instance_name=None,
     # zone='fake-zone', disk_name='non-existent-disk') Should raise an
     # exception
-    self.assertRaises(RuntimeError,
-                      gcp.CreateDiskCopy,
-                      FAKE_SOURCE_PROJECT.project_id,
-                      FAKE_ANALYSIS_PROJECT.project_id,
-                      instance_name=None,
-                      zone=FAKE_INSTANCE.zone,
-                      disk_name='non-existent-disk')
+    self.assertRaises(
+        RuntimeError, gcp.CreateDiskCopy, FAKE_SOURCE_PROJECT.project_id,
+        FAKE_ANALYSIS_PROJECT.project_id, instance_name=None,
+        zone=FAKE_INSTANCE.zone, disk_name='non-existent-disk')
 
     # create_disk_copy(src_proj, dst_proj,
     # instance_name='non-existent-instance', zone='fake-zone',
     # disk_name=None) Should raise an exception
-    self.assertRaises(RuntimeError,
-                      gcp.CreateDiskCopy,
-                      FAKE_SOURCE_PROJECT.project_id,
-                      FAKE_ANALYSIS_PROJECT.project_id,
-                      instance_name='non-existent-instance',
-                      zone=FAKE_INSTANCE.zone,
-                      disk_name='')
+    self.assertRaises(
+        RuntimeError, gcp.CreateDiskCopy, FAKE_SOURCE_PROJECT.project_id,
+        FAKE_ANALYSIS_PROJECT.project_id, instance_name='non-existent-instance',
+        zone=FAKE_INSTANCE.zone, disk_name='')
 
   def testGenerateDiskName(self):
     """Test that the generated disk name is always within GCP boundaries.
@@ -625,24 +567,18 @@ class GCPTest(unittest.TestCase):
     letter, or digit, except the last character, which cannot be a dash.
     """
 
-    disk_name = gcp.GenerateDiskName(
-        FAKE_SNAPSHOT
-    )
+    disk_name = gcp.GenerateDiskName(FAKE_SNAPSHOT)
     self.assertEqual(disk_name, 'fake-snapshot-857c0b16-copy')
     self.assertTrue(REGEX_DISK_NAME.match(disk_name))
 
-    disk_name = gcp.GenerateDiskName(
-        FAKE_SNAPSHOT_LONG_NAME
-    )
+    disk_name = gcp.GenerateDiskName(FAKE_SNAPSHOT_LONG_NAME)
     self.assertEqual(
         disk_name,
         'this-is-a-kind-of-long-fake-snapshot-name-and-is--857c0b16-copy')
     self.assertTrue(REGEX_DISK_NAME.match(disk_name))
 
     disk_name = gcp.GenerateDiskName(
-        FAKE_SNAPSHOT,
-        disk_name_prefix='some-not-so-long-disk-name-prefix'
-    )
+        FAKE_SNAPSHOT, disk_name_prefix='some-not-so-long-disk-name-prefix')
     self.assertEqual(
         disk_name,
         'some-not-so-long-disk-name-prefix-fake-snapshot-857c0b16-copy')
@@ -650,8 +586,7 @@ class GCPTest(unittest.TestCase):
 
     disk_name = gcp.GenerateDiskName(
         FAKE_SNAPSHOT_LONG_NAME,
-        disk_name_prefix='some-not-so-long-disk-name-prefix'
-    )
+        disk_name_prefix='some-not-so-long-disk-name-prefix')
     self.assertEqual(
         disk_name,
         'some-not-so-long-disk-name-prefix-this-is-a-kind--857c0b16-copy')
@@ -660,8 +595,7 @@ class GCPTest(unittest.TestCase):
     disk_name = gcp.GenerateDiskName(
         FAKE_SNAPSHOT,
         disk_name_prefix='some-really-really-really-really-really-really-long'
-                         '-disk-name-prefix'
-    )
+        '-disk-name-prefix')
     self.assertEqual(
         disk_name,
         'some-really-really-really-really-really-really-lo-857c0b16-copy')
@@ -670,16 +604,16 @@ class GCPTest(unittest.TestCase):
     disk_name = gcp.GenerateDiskName(
         FAKE_SNAPSHOT_LONG_NAME,
         disk_name_prefix='some-really-really-really-really-really-really-long'
-                         '-disk-name-prefix'
-    )
+        '-disk-name-prefix')
     self.assertEqual(
         disk_name,
         'some-really-really-really-really-really-really-lo-857c0b16-copy')
     self.assertTrue(REGEX_DISK_NAME.match(disk_name))
 
     # Disk prefix cannot start with a capital letter
-    self.assertRaises(ValueError, gcp.GenerateDiskName, FAKE_SNAPSHOT,
-                      'Some-prefix-that-starts-with-a-capital-letter')
+    self.assertRaises(
+        ValueError, gcp.GenerateDiskName, FAKE_SNAPSHOT,
+        'Some-prefix-that-starts-with-a-capital-letter')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replacing GceOperation and __ExecuteOperation with BlockOperation which is what both methods actually do. Made changes to have a single authenticated GCE or GCF client created once in the project and avoid creating new one with every API call. Changed few things in unittests which makes more sense considering the new changes in gcp.py. Movedinstance start and delete to setUpClass and tearDownClass in e2e disks to avoid creating and deleting the analysis vm for every test which makes the e2e test takes too long.
