### PR TITLE
Add example GCP CLI tool.

### DIFF
--- a/examples/gcp_cli.py
+++ b/examples/gcp_cli.py
@@ -29,7 +29,10 @@ def ListInstances(args):
   instances = project.ListInstances()
 
   print('Instances found:')
-  print(instances)
+  for instance in instances:
+    print(
+        'Name: {0}, Bootdisk: {1}'.format(
+            instance, instances[instance].GetBootDisk().name))
 
 
 def ListDisks(args):
@@ -42,7 +45,8 @@ def ListDisks(args):
   project = gcp.GoogleCloudProject(args.project)
   disks = project.ListDisks()
   print('Disks found:')
-  print(disks)
+  for disk in disks:
+    print('Name: {0}, Zone: {1}'.format(disk, disks[disk].zone))
 
 
 def CreateDiskCopy(args):
@@ -55,8 +59,8 @@ def CreateDiskCopy(args):
   disk = gcp.CreateDiskCopy(
       args.project, args.dstproject, args.instancename, args.zone)
 
-  print('Disk copy succesful:')
-  print(disk.name)
+  print('Disk copy completed.')
+  print('Name: {0}'.format(disk.name))
 
 
 if __name__ == '__main__':

--- a/examples/gcp_cli.py
+++ b/examples/gcp_cli.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Demo CLI tool for GCP."""
+
+import argparse
+from libcloudforensics import gcp
+
+
+def ListInstances(args):
+  """List GCE instances in GCP project.
+
+  Args:
+    args (dict): Arguments from ArgumentParser.
+  """
+
+  project = gcp.GoogleCloudProject(args.project)
+  instances = project.ListInstances()
+
+  print('Instances found:')
+  print(instances)
+
+
+def ListDisks(args):
+  """List GCE disks in GCP project.
+
+  Args:
+    args (dict): Arguments from ArgumentParser.
+  """
+
+  project = gcp.GoogleCloudProject(args.project)
+  disks = project.ListDisks()
+  print('Disks found:')
+  print(disks)
+
+
+def CreateDiskCopy(args):
+  """Copy GCE disks to other GCP project.
+
+  Args:
+    args (dict): Arguments from ArgumentParser.
+  """
+
+  disk = gcp.CreateDiskCopy(
+      args.project, args.dstproject, args.instancename, args.zone)
+
+  print('Disk copy succesful:')
+  print(disk.name)
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Demo CLI tool for GCP')
+  parser.add_argument('--project', help='The GCP project name')
+
+  subparsers = parser.add_subparsers()
+
+  parser_listdisks = subparsers.add_parser('listdisks')
+  parser_listdisks.set_defaults(func=ListDisks)
+
+  parser_listdisks = subparsers.add_parser('listinstances')
+  parser_listdisks.set_defaults(func=ListInstances)
+
+  parser_creatediskcopy = subparsers.add_parser('creatediskcopy')
+  parser_creatediskcopy.add_argument(
+      '--dstproject', help='Destination GCP project')
+  parser_creatediskcopy.add_argument('--zone', help='Zone to create disk in')
+  parser_creatediskcopy.add_argument(
+      '--instancename', help='Instance to copy disk from')
+  parser_creatediskcopy.set_defaults(func=CreateDiskCopy)
+
+  parsed_args = parser.parse_args()
+  if parsed_args.func:
+    parsed_args.func(parsed_args)

--- a/examples/gcp_cli.py
+++ b/examples/gcp_cli.py
@@ -30,9 +30,8 @@ def ListInstances(args):
 
   print('Instances found:')
   for instance in instances:
-    print(
-        'Name: {0}, Bootdisk: {1}'.format(
-            instance, instances[instance].GetBootDisk().name))
+    bootdisk_name = instances[instance].GetBootDisk().name
+    print('Name: {0:s}, Bootdisk: {1:s}'.format(instance, bootdisk_name))
 
 
 def ListDisks(args):
@@ -46,7 +45,7 @@ def ListDisks(args):
   disks = project.ListDisks()
   print('Disks found:')
   for disk in disks:
-    print('Name: {0}, Zone: {1}'.format(disk, disks[disk].zone))
+    print('Name: {0:s}, Zone: {1:s}'.format(disk, disks[disk].zone))
 
 
 def CreateDiskCopy(args):
@@ -60,7 +59,7 @@ def CreateDiskCopy(args):
       args.project, args.dstproject, args.instancename, args.zone)
 
   print('Disk copy completed.')
-  print('Name: {0}'.format(disk.name))
+  print('Name: {0:s}'.format(disk.name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Wrote small GCP example CLI tool to make it easy to:
- list instances
- list disks
- create a disk copy
```
$ python gcp_cli.py --project my-proj listinstances
Instances found:
Name: instance-1, Bootdisk: disk1

$ python gcp_cli.py --project my-proj listdisks
Disks found:
Name: disk-1, Zone:us-central1-a
Name: disk-2, Zone:us-central1-a

$ python gcp_cli.py --project my-proj creatediskcopy --dstproject project2 --zone us-east --instancename badvm1 
Disk copy completed.
Name: evidence-instance-1-20200508152755-79eb55f3-copy

$ python gcp_cli.py -h
usage: gcp_cli.py [-h] [--project PROJECT]
                  {listdisks,listinstances,creatediskcopy} ...

Demo CLI tool for GCP

positional arguments:
  {listdisks,listinstances,creatediskcopy}

optional arguments:
  -h, --help            show this help message and exit
  --project PROJECT     The GCP project name
```