### PR TITLE
Add support for sharing encrypted EBS resources cross account

### DIFF
--- a/libcloudforensics/aws.py
+++ b/libcloudforensics/aws.py
@@ -907,7 +907,8 @@ def CreateVolumeCopy(zone,
     AWSVolume: An AWS EBS Volume object.
 
   Raises:
-    RuntimeError: If there are errors copying the volume.
+    RuntimeError: If there are errors copying the volume, or errors during
+        KMS key creation/sharing if the target volume is encrypted.
     ValueError: If both instance_id and volume_id are missing.
   """
 

--- a/libcloudforensics/aws.py
+++ b/libcloudforensics/aws.py
@@ -20,6 +20,7 @@ analysis virtual machine to be used in incident response.
 
 import binascii
 import datetime
+import json
 import logging
 import re
 
@@ -30,6 +31,7 @@ log = logging.getLogger()
 
 EC2_SERVICE = 'ec2'
 ACCOUNT_SERVICE = 'sts'
+KMS_SERVICE = 'kms'
 REGEX_TAG_VALUE = re.compile('^.{1,255}$')
 
 
@@ -203,8 +205,11 @@ class AWSAccount:
 
       for volume in response['Volumes']:
         volume_id = volume['VolumeId']
-        aws_volume = AWSVolume(
-            volume_id, self, self.default_region, volume['AvailabilityZone'])
+        aws_volume = AWSVolume(volume_id,
+                               self,
+                               self.default_region,
+                               volume['AvailabilityZone'],
+                               volume['Encrypted'])
 
         for tag in volume.get('Tags', []):
           if tag.get('Key') == 'Name':
@@ -394,13 +399,15 @@ class AWSAccount:
   def CreateVolumeFromSnapshot(self,
                                snapshot,
                                volume_name=None,
-                               volume_name_prefix=''):
+                               volume_name_prefix='',
+                               kms_key_id=None):
     """Create a new volume based on a snapshot.
 
     Args:
       snapshot (AWSSnapshot): Snapshot to use.
       volume_name (str): Optional. String to use as new volume name.
       volume_name_prefix (str): Optional. String to prefix the volume name with.
+      kms_key_id (str): Optional. A KMS key id to encrypt the volume with.
 
     Returns:
       AWSVolume: An AWS EBS Volume.
@@ -420,12 +427,19 @@ class AWSAccount:
 
     client = self.ClientApi(EC2_SERVICE)
     try:
-      volume = client.create_volume(
-          AvailabilityZone=snapshot.availability_zone,
-          SnapshotId=snapshot.snapshot_id,
-          TagSpecifications=[GetTagForResourceType('volume', volume_name)])
+      create_volume_args = {
+          'AvailabilityZone': snapshot.availability_zone,
+          'SnapshotId': snapshot.snapshot_id,
+          'TagSpecifications': [GetTagForResourceType('volume', volume_name)]
+      }
+      if kms_key_id:
+        create_volume_args['Encrypted'] = True
+        create_volume_args['KmsKeyId'] = kms_key_id
+
+      volume = client.create_volume(**create_volume_args)
       volume_id = volume['VolumeId']
       zone = volume['AvailabilityZone']
+      encrypted = volume['Encrypted']
       # Wait for volume creation completion
       client.get_waiter('volume_available').wait(VolumeIds=[volume_id])
     except (client.exceptions.ClientError,
@@ -438,6 +452,7 @@ class AWSAccount:
                      self,
                      self.default_region,
                      zone,
+                     encrypted,
                      name=volume_name)
 
   def GetAccountInformation(self, info):
@@ -464,6 +479,72 @@ class AWSAccount:
     if not account_information.get(info):
       raise KeyError('Key must be one of ["UserId", "Account", "Arn"]')
     return account_information.get(info)
+
+  def CreateSharedKMSKey(self, aws_account_id):
+    """Create a KMS key and share it with aws_account_id
+
+    Args:
+      aws_account_id (str): The AWS Account ID to share the KMS key with.
+
+    Returns:
+      str: The KMS key ID that was created.
+
+    Raises:
+      RuntimeError: If the key could not be created.
+    """
+
+    share_policy = {
+        'Sid': 'Allow use of the key',
+        'Effect': 'Allow',
+        'Principal': {
+            'AWS': 'arn:aws:iam::{0:s}:root'.format(aws_account_id)
+        },
+        'Action': [
+            'kms:Encrypt',
+            'kms:Decrypt',
+            'kms:ReEncrypt*'
+        ],
+        'Resource': '*'
+    }
+    client = self.ClientApi(KMS_SERVICE)
+    try:
+      kms_key = client.create_key()
+      # If the call to the API is successful, then the response contains the
+      # key ID
+      kms_key_id = kms_key['KeyMetadata']['KeyId']
+      policy = json.loads(client.get_key_policy(
+          KeyId=kms_key_id, PolicyName='default')['Policy'])
+      policy['Statement'].append(share_policy)
+      # Update the key policy so that it is shared with the AWS account.
+      client.put_key_policy(
+          KeyId=kms_key_id, PolicyName='default', Policy=json.dumps(policy))
+      return kms_key_id
+    except client.exceptions.ClientError as exception:
+      raise RuntimeError('Could not create KMS key: {0:s}'.format(
+          str(exception)))
+
+  def DeleteKMSKey(self, kms_key_id):
+    """Delete a KMS key.
+
+    Schedule the KMS key for deletion. By default, users have a 30 days
+        window before the key gets deleted.
+
+    Args:
+      kms_key_id (str): The ID of the KMS key to delete.
+
+    Raises:
+      RuntimeError: If the key could not be scheduled for deletion.
+    """
+
+    if not kms_key_id:
+      return
+
+    client = self.ClientApi(KMS_SERVICE)
+    try:
+      client.schedule_key_deletion(KeyId=kms_key_id)
+    except client.exceptions.ClientError as exception:
+      raise RuntimeError('Could not schedule the KMS key: {0:s} for '
+                         'deletion'.format(str(exception)))
 
   def _GenerateVolumeName(self, snapshot, volume_name_prefix=None):
     """Generate a new volume name given a volume's snapshot.
@@ -577,22 +658,30 @@ class AWSElasticBlockStore:
     aws_account (AWSAccount): The account for the resource.
     region (str): The region the EBS is in.
     availability_zone (str): The zone within the region in which the EBS is.
+    encrypted (bool): True if the EBS resource is encrypted, False otherwise.
     name (str): The name tag of the EBS resource, if existing.
   """
 
-  def __init__(self, aws_account, region, availability_zone, name=None):
+  def __init__(self,
+               aws_account,
+               region,
+               availability_zone,
+               encrypted,
+               name=None):
     """Initialize the AWS EBS resource.
 
     Args:
       aws_account (AWSAccount): The account for the resource.
       region (str): The region the EBS is in.
       availability_zone (str): The zone within the region in which the EBS is.
+      encrypted (bool): True if the EBS resource is encrypted, False otherwise.
       name (str): Optional. The name tag of the EBS resource, if existing.
     """
 
     self.aws_account = aws_account
     self.region = region
     self.availability_zone = availability_zone
+    self.encrypted = encrypted
     self.name = name
 
 
@@ -604,7 +693,10 @@ class AWSVolume(AWSElasticBlockStore):
     aws_account (AWSAccount): The account for the volume.
     region (str): The region the volume is in.
     availability_zone (str): The zone within the region in which the volume is.
+    encrypted (bool): True if the volume is encrypted, False otherwise.
     name (str): The name tag of the volume, if existing.
+    device_name (str): The device name (e.g. /dev/spf) of the
+        volume when it is attached to an instance, if applicable.
   """
 
   def __init__(self,
@@ -612,6 +704,7 @@ class AWSVolume(AWSElasticBlockStore):
                aws_account,
                region,
                availability_zone,
+               encrypted,
                name=None,
                device_name=None):
     """Initialize an AWS EBS volume.
@@ -622,6 +715,7 @@ class AWSVolume(AWSElasticBlockStore):
       region (str): The region the volume is in.
       availability_zone (str): The zone within the region in which the volume
           is.
+      encrypted (bool): True if the volume is encrypted, False otherwise.
       name (str): Optional. The name tag of the volume, if existing.
       device_name (str): Optional. The device name (e.g. /dev/spf) of the
           volume when it is attached to an instance, if applicable.
@@ -630,6 +724,7 @@ class AWSVolume(AWSElasticBlockStore):
     super(AWSVolume, self).__init__(aws_account,
                                     region,
                                     availability_zone,
+                                    encrypted,
                                     name)
     self.volume_id = volume_id
     self.device_name = device_name
@@ -673,6 +768,15 @@ class AWSVolume(AWSElasticBlockStore):
 
     return AWSSnapshot(snapshot_id, self, name=snapshot_name)
 
+  def Delete(self):
+    """Delete a volume."""
+    client = self.aws_account.ClientApi(EC2_SERVICE)
+    try:
+      client.delete_volume(VolumeId=self.volume_id)
+    except client.exceptions.ClientError as exception:
+      raise RuntimeError('Could not delete volume {0:s}: {1:s}'.format(
+          self.volume_id, str(exception)))
+
 
 class AWSSnapshot(AWSElasticBlockStore):
   """Class representing an AWS EBS snapshot.
@@ -695,6 +799,7 @@ class AWSSnapshot(AWSElasticBlockStore):
     super(AWSSnapshot, self).__init__(volume.aws_account,
                                       volume.region,
                                       volume.availability_zone,
+                                      volume.encrypted,
                                       name)
     self.snapshot_id = snapshot_id
     self.volume = volume
@@ -722,7 +827,6 @@ class AWSSnapshot(AWSElasticBlockStore):
         Attribute='createVolumePermission',
         CreateVolumePermission={
             'Add': [{
-                'Group': 'all',
                 'UserId': aws_account_id
             }]
         },
@@ -802,6 +906,7 @@ def CreateVolumeCopy(zone,
 
   source_account = AWSAccount(zone, aws_profile=src_account)
   destination_account = AWSAccount(zone, aws_profile=dst_account)
+  shared_kms_key_id = None
 
   try:
     if volume_id:
@@ -818,11 +923,27 @@ def CreateVolumeCopy(zone,
         'Account')
 
     if source_account_id != destination_account_id:
+      if volume_to_copy.encrypted:
+        # Generate one-time use KMS key that will be shared with the
+        # destination account.
+        shared_kms_key_id = source_account.CreateSharedKMSKey(
+            destination_account_id)
+        temporary_volume = source_account.CreateVolumeFromSnapshot(
+            snapshot, kms_key_id=shared_kms_key_id)
+        # The old snapshot is not needed anymore since we have created the
+        # temporary volume
+        snapshot.Delete()
+        # Get a new snapshot
+        snapshot = temporary_volume.Snapshot()
+        # Delete the temporary volume
+        temporary_volume.Delete()
       snapshot.ShareWithAWSAccount(destination_account_id)
 
     new_volume = destination_account.CreateVolumeFromSnapshot(
         snapshot, volume_name_prefix='evidence')
     snapshot.Delete()
+    # Delete the one-time use KMS key, if one was generated
+    source_account.DeleteKMSKey(shared_kms_key_id)
     log.info('Volume {0:s} successfully copied to {1:s}'.format(
         volume_to_copy.volume_id, new_volume.volume_id))
 

--- a/tests/unittest/aws_test.py
+++ b/tests/unittest/aws_test.py
@@ -36,12 +36,14 @@ FAKE_VOLUME = aws.AWSVolume(
     'fake-volume-id',
     FAKE_AWS_ACCOUNT,
     'fake-zone-2',
-    'fake-zone-2b')
+    'fake-zone-2b',
+    False)
 FAKE_BOOT_VOLUME = aws.AWSVolume(
     'fake-boot-volume-id',
     FAKE_AWS_ACCOUNT,
     'fake-zone-2',
     'fake-zone-2b',
+    False,
     name='fake-boot-volume',
     device_name='/dev/spf')
 FAKE_SNAPSHOT = aws.AWSSnapshot(
@@ -85,10 +87,12 @@ MOCK_DESCRIBE_VOLUMES = {
     'Volumes': [{
         'VolumeId': FAKE_VOLUME.volume_id,
         'AvailabilityZone': FAKE_VOLUME.availability_zone,
+        'Encrypted': FAKE_VOLUME.encrypted,
         'Attachments': []
     }, {
         'VolumeId': FAKE_BOOT_VOLUME.volume_id,
         'AvailabilityZone': FAKE_BOOT_VOLUME.availability_zone,
+        'Encrypted': FAKE_BOOT_VOLUME.encrypted,
         'Attachments': []
     }]
 }
@@ -97,6 +101,7 @@ MOCK_DESCRIBE_VOLUMES_TAGS = {
     'Volumes': [{
         'VolumeId': FAKE_BOOT_VOLUME.volume_id,
         'AvailabilityZone': FAKE_BOOT_VOLUME.availability_zone,
+        'Encrypted': FAKE_BOOT_VOLUME.encrypted,
         'Attachments': [{
             'State': 'attached',
             'Device': FAKE_BOOT_VOLUME.device_name
@@ -120,7 +125,8 @@ MOCK_LIST_VOLUMES = {
 
 MOCK_CREATE_VOLUME = {
     'VolumeId': 'fake-volume-from-snapshot-id',
-    'AvailabilityZone': FAKE_SNAPSHOT.availability_zone
+    'AvailabilityZone': FAKE_SNAPSHOT.availability_zone,
+    'Encrypted': False
 }
 
 MOCK_CREATE_SNAPSHOT = {


### PR DESCRIPTION
Few changes:

- Added `encrypted` attribute to `AWSVolume` class.
- When calling `CreateVolumeCopy()` with a destination account that is not the same as the source account, we now check if the target volume is encrypted. If so, a one-time use KMS shared key (between source and destination account) is generated. Subsequently, the initial target volume is duplicated + encrypted with the temporary shared key. We then use this temporary volume for the remainder of the code (i.e., getting a new snapshot out of that temporary volume, sharing it with the destination account, and creating a copy within the destination account).

After execution, temporary volumes, snapshots and keys are deleted. The copy of the volume that sits in the destination account is encrypted with the default EBS/KMS key particular to that account.

Closes #63 

Signed-off-by: Theo Giovanna <gtheo@google.com>