### PR TITLE
Add global CLI tool for libcloudforensics

### DIFF
--- a/examples/gcp_cli.py
+++ b/examples/gcp_cli.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Demo CLI tool for GCP."""
 
-import argparse
 import json
 from libcloudforensics import gcp
 
@@ -87,35 +86,3 @@ def QueryLogs(args):
   print('Found {0:d} log entries:'.format(len(results)))
   for line in results:
     print(json.dumps(line))
-
-
-if __name__ == '__main__':
-  parser = argparse.ArgumentParser(description='Demo CLI tool for GCP')
-  parser.add_argument('--project', help='The GCP project name')
-
-  subparsers = parser.add_subparsers()
-
-  parser_listdisks = subparsers.add_parser('listdisks')
-  parser_listdisks.set_defaults(func=ListDisks)
-
-  parser_listdisks = subparsers.add_parser('listinstances')
-  parser_listdisks.set_defaults(func=ListInstances)
-
-  parser_creatediskcopy = subparsers.add_parser('creatediskcopy')
-  parser_creatediskcopy.add_argument(
-      '--dstproject', help='Destination GCP project')
-  parser_creatediskcopy.add_argument('--zone', help='Zone to create disk in')
-  parser_creatediskcopy.add_argument(
-      '--instancename', help='Instance to copy disk from')
-  parser_creatediskcopy.set_defaults(func=CreateDiskCopy)
-
-  parser_listlogs = subparsers.add_parser('listlogs')
-  parser_listlogs.set_defaults(func=ListLogs)
-
-  parser_querylogs = subparsers.add_parser('querylogs')
-  parser_querylogs.add_argument('--filter', help='Query filter')
-  parser_querylogs.set_defaults(func=QueryLogs)
-
-  parsed_args = parser.parse_args()
-  if parsed_args.func:
-    parsed_args.func(parsed_args)

--- a/examples/libcloudforensics.py
+++ b/examples/libcloudforensics.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make sure that your AWS/GCP  credentials are configured correclty
+"""CLI tools for libcloudforensics"""
+
+import sys
+
+import argparse
+from examples import aws_cli, gcp_cli
+
+
+PROVIDER_TO_FUNC = {
+    'aws': {
+        'listinstances': aws_cli.ListInstances,
+        'listdisks': aws_cli.ListVolumes,
+        'copydisk': aws_cli.CreateVolumeCopy,
+        'querylogs': aws_cli.QueryLogs
+    },
+    'gcp': {
+        'listinstances': gcp_cli.ListInstances,
+        'listdisks': gcp_cli.ListDisks,
+        'copydisk': gcp_cli.CreateDiskCopy,
+        'querylogs': gcp_cli.QueryLogs,
+        'listlogs': gcp_cli.ListLogs
+    }
+}
+
+
+def AddParser(provider, provider_parser, func, func_helper, args=None):
+  """Create a new parser object for a provider's functionality.
+
+  Args:
+    provider (str): The cloud provider offering the function. This should be
+        one of ['aws', 'gcp'].
+    provider_parser (_SubParsersAction): A provider's subparser object from
+        argparse.ArgumentParser.
+    func (str): The name of the function to look for in the given provider
+        and to add parsing options for.
+    func_helper (str): A helper text describing what the function does.
+    args (list(tuple(str, str, str|None))): Optional. A list of arguments to add
+        to the parser. Each argument is a tuple containing the action (str) to
+        add to the parser, a helper text (str), and a default value (str,
+        optional).
+
+  Raises:
+    NotImplementedError: If the requested provider or function is not
+        implemented.
+  """
+  if provider not in PROVIDER_TO_FUNC:
+    raise NotImplementedError('Requested provider is not implemented')
+  if func not in PROVIDER_TO_FUNC[provider]:
+    raise NotImplementedError('Requested functionality {0:s} is not '
+                              'implemented for provider {1:s}'.format(
+                                  func, provider))
+  func_parser = provider_parser.add_parser(func, help=func_helper)
+  if args:
+    for argument, helper_text, default_value in args:
+      kwargs = {'help': helper_text, 'default': default_value}
+      func_parser.add_argument(argument, **kwargs)
+  func_parser.set_defaults(func=PROVIDER_TO_FUNC[provider][func])
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='CLI tool for AWS and GCP.')
+  subparsers = parser.add_subparsers()
+
+  aws_parser = subparsers.add_parser('aws', help='Tools for AWS')
+  gcp_parser = subparsers.add_parser('gcp', help='Tools for GCP')
+
+  # AWS parser options
+  aws_parser.add_argument('zone', help='The AWS zone in which resources are '
+                                       'located, e.g. us-east-2b')
+  aws_subparsers = aws_parser.add_subparsers()
+  AddParser('aws', aws_subparsers, 'listinstances',
+            'List EC2 instances in AWS account.')
+  AddParser('aws', aws_subparsers, 'listdisks',
+            'List EBS volumes in AWS account.')
+  AddParser('aws', aws_subparsers, 'copydisk', 'Create an AWS volume copy.',
+            args=[
+                ('--instance_id', 'The AWS unique instance ID', None),
+                ('--volume_id', 'The AWS unique volume ID of the volume to '
+                                'copy. If none specified, then --instance_id '
+                                'must be specified and the boot volume of the '
+                                'AWS instance will be copied.', None),
+                ('--src_account', 'The name of the profile for the source '
+                                  'account, as defined in the AWS credentials '
+                                  'file.', None),
+                ('--dst_account', 'The name of the profile for the destination '
+                                  'account, as defined in the AWS credentials '
+                                  'file.', None)
+            ])
+  AddParser('aws', aws_subparsers, 'querylogs', 'Query AWS CloudTrail logs',
+            args=[
+                ('--filter', 'Query filter: \'value,key\'', ()),
+                ('--start', 'Start date for query (2020-05-01 11:13:00)', None),
+                ('--end', 'End date for query (2020-05-01 11:13:00)', None)
+            ])
+
+  # GCP parser options
+  gcp_parser.add_argument('project', help='Source GCP project.')
+  gcp_subparsers = gcp_parser.add_subparsers()
+  AddParser('gcp', gcp_subparsers, 'listinstances',
+            'List GCE instances in GCP project.')
+  AddParser('gcp', gcp_subparsers, 'listdisks',
+            'List GCE disks in GCP project.')
+  AddParser('gcp', gcp_subparsers, 'copydisk', 'Create a GCP disk copy.',
+            args=[
+                ('dstproject', 'Destination GCP project.', ''),
+                ('instancename', 'Name of the instance to copy disk from.', ''),
+                ('zone', 'Zone to create the disk in.', '')
+            ])
+  AddParser('gcp', gcp_subparsers, 'querylogs', 'Query GCP logs.',
+            args=[
+                ('--filter', 'Query filter.', None)
+            ])
+  AddParser('gcp', gcp_subparsers, 'listlogs', 'List GCP logs for a project.')
+
+  if len(sys.argv) == 1:
+    parser.print_help()
+    sys.exit(1)
+
+  parsed_args = parser.parse_args()
+
+  if hasattr(parsed_args, 'func'):
+    parsed_args.func(parsed_args)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ description = (
 
 def parse_requirements(filename):
   with open(filename) as requirements:
-      # Skipping -i https://pypi.org/simple
+    # Skipping -i https://pypi.org/simple
     return requirements.readlines()[1:]
 
 
@@ -59,6 +59,7 @@ setup(
     package_data={
       'libcloudforensics': ['scripts/*']
     },
+    scripts=['examples/libcloudforensics.py'],
     zip_safe=False,
     install_requires=[req for req in parse_requirements('requirements.txt')],
     tests_require=[req for req in parse_requirements('requirements-dev.txt')],


### PR DESCRIPTION
This adds `examples/libcloudforensics.py` to the `setup.py` such that installing the module installs a global `libcloudforensics.py` CLI tool, which groups functionalities that were defined in both `aws_cli.py` and `gcp_cli.py`.

Usage:

```
bash:$ libcloudforensics.py aws 'zone' listinstances
bash:$ libcloudforensics.py gcp 'project' listinstances
...
```

Signed-off-by: Theo Giovanna <gtheo@google.com>