### PR TITLE
Migrate src/dst_account to src/dst_profile in AWS

### DIFF
--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -66,8 +66,8 @@ def CreateVolumeCopy(args):
                                            dst_zone=args.dst_zone,
                                            instance_id=args.instance_id,
                                            volume_id=args.volume_id,
-                                           src_account=args.src_account,
-                                           dst_account=args.dst_account)
+                                           src_profile=args.src_profile,
+                                           dst_profile=args.dst_profile)
   print(
       'Done! Volume {0:s} successfully created. You will find it in '
       'your AWS account under the name {1:s}.'.format(

--- a/examples/libcloudforensics.py
+++ b/examples/libcloudforensics.py
@@ -100,10 +100,10 @@ def Main():
                                 'copy. If none specified, then --instance_id '
                                 'must be specified and the boot volume of the '
                                 'AWS instance will be copied.', None),
-                ('--src_account', 'The name of the profile for the source '
+                ('--src_profile', 'The name of the profile for the source '
                                   'account, as defined in the AWS credentials '
                                   'file.', None),
-                ('--dst_account', 'The name of the profile for the destination '
+                ('--dst_profile', 'The name of the profile for the destination '
                                   'account, as defined in the AWS credentials '
                                   'file.', None)
             ])


### PR DESCRIPTION
In order to be more consistent with AWS notations, migrate `src_account` and `dst_account` variables to `src_profile` and `dst_profile` respectively, as accounts are defined by profiles in AWS credential files.

Closes #97 

Signed-off-by: Theo Giovanna <gtheo@google.com>