### PR TITLE
Add option to copy volume in a different destination region in AWS

### DIFF
--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -62,10 +62,12 @@ def CreateVolumeCopy(args):
     args (dict): Arguments from ArgumentParser.
   """
   print('Starting volume copy...')
-  volume_copy = forensics.CreateVolumeCopy(
-      args.zone, dst_zone=args.dst_zone, instance_id=args.instance_id,
-      volume_id=args.volume_id, src_account=args.src_account,
-      dst_account=args.dst_account)
+  volume_copy = forensics.CreateVolumeCopy(args.zone,
+                                           dst_zone=args.dst_zone,
+                                           instance_id=args.instance_id,
+                                           volume_id=args.volume_id,
+                                           src_account=args.src_account,
+                                           dst_account=args.dst_account)
   print(
       'Done! Volume {0:s} successfully created. You will find it in '
       'your AWS account under the name {1:s}.'.format(

--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -63,8 +63,9 @@ def CreateVolumeCopy(args):
   """
   print('Starting volume copy...')
   volume_copy = forensics.CreateVolumeCopy(
-      args.zone, instance_id=args.instance_id, volume_id=args.volume_id,
-      src_account=args.src_account, dst_account=args.dst_account)
+      args.zone, dst_zone=args.dst_zone, instance_id=args.instance_id,
+      volume_id=args.volume_id, src_account=args.src_account,
+      dst_account=args.dst_account)
   print(
       'Done! Volume {0:s} successfully created. You will find it in '
       'your AWS account under the name {1:s}.'.format(

--- a/examples/libcloudforensics.py
+++ b/examples/libcloudforensics.py
@@ -90,6 +90,9 @@ if __name__ == '__main__':
             'List EBS volumes in AWS account.')
   AddParser('aws', aws_subparsers, 'copydisk', 'Create an AWS volume copy.',
             args=[
+                ('--dst_zone', 'The AWS zone in which to copy the volume. By '
+                               'default this is the same as \'zone\'.',
+                 None),
                 ('--instance_id', 'The AWS unique instance ID', None),
                 ('--volume_id', 'The AWS unique volume ID of the volume to '
                                 'copy. If none specified, then --instance_id '

--- a/examples/libcloudforensics.py
+++ b/examples/libcloudforensics.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
   AddParser('aws', aws_subparsers, 'copydisk', 'Create an AWS volume copy.',
             args=[
                 ('--dst_zone', 'The AWS zone in which to copy the volume. By '
-                               'default this is the same as \'zone\'.',
+                               'default this is the same as "zone".',
                  None),
                 ('--instance_id', 'The AWS unique instance ID', None),
                 ('--volume_id', 'The AWS unique volume ID of the volume to '

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -63,7 +63,7 @@ def CreateVolumeCopy(zone,
       dst_account='forensics')
 
   Args:
-    zone (str): The AWS zone in which the volume is located, e.g. us-east-2b.
+    zone (str): The AWS zone in which the volume is located, e.g. 'us-east-2b'.
     dst_zone (str): Optional. The AWS zone in which to create the volume
         copy. By default, this is the same as 'zone'.
     instance_id (str): Optional. Instance ID of the instance using the volume
@@ -126,7 +126,8 @@ def CreateVolumeCopy(zone,
     if dst_zone:
       # Assign the new zone to the destination account and assign it to the
       # snapshot so that it can copy it
-      destination_account.__init__(dst_zone, aws_profile=dst_account)
+      destination_account = account.AWSAccount(
+          dst_zone, aws_profile=dst_account)
       snapshot.aws_account = destination_account
       snapshot = snapshot.Copy(delete=True, deletion_account=source_account)
 

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -19,6 +19,7 @@ from libcloudforensics.providers.aws.internal import account
 
 
 def CreateVolumeCopy(zone,
+                     dst_zone=None,
                      instance_id=None,
                      volume_id=None,
                      src_account=None,
@@ -62,7 +63,9 @@ def CreateVolumeCopy(zone,
       dst_account='forensics')
 
   Args:
-    zone (str): The zone within the region to create the new resource in.
+    zone (str): The AWS zone in which the volume is located, e.g. us-east-2b.
+    dst_zone (str): Optional. The AWS zone in which to create the volume
+        copy. By default, this is the same as 'zone'.
     instance_id (str): Optional. Instance ID of the instance using the volume
         to be copied. If specified, the boot volume of the instance will be
         copied. If volume_id is also specified, then the volume pointed by
@@ -117,11 +120,15 @@ def CreateVolumeCopy(zone,
             kms_key_id, destination_account_id)
         # Create a copy of the initial snapshot and encrypts it with the
         # shared key
-        temporary_snapshot = snapshot.Copy(kms_key_id=kms_key_id)
-        # Delete the initial snapshot
-        snapshot.Delete()
-        snapshot = temporary_snapshot
+        snapshot = snapshot.Copy(kms_key_id=kms_key_id, delete=True)
       snapshot.ShareWithAWSAccount(destination_account_id)
+
+    if dst_zone:
+      # Assign the new zone to the destination account and assign it to the
+      # snapshot so that it can copy it
+      destination_account.__init__(dst_zone, aws_profile=dst_account)
+      snapshot.aws_account = destination_account
+      snapshot = snapshot.Copy(delete=True, deletion_account=source_account)
 
     new_volume = destination_account.CreateVolumeFromSnapshot(
         snapshot, volume_name_prefix='evidence')

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -565,10 +565,12 @@ class AWSAccount:
             'AWS': 'arn:aws:iam::{0:s}:root'.format(aws_account_id)
         },
         'Action': [
+            # kms:*crypt and kms:ReEncrypt* are necessary to transfer
+            # encrypted EBS resources across accounts.
             'kms:Encrypt',
             'kms:Decrypt',
             'kms:ReEncrypt*',
-            # This permission is necessary to transfer encrypted EBS
+            # kms:CreateGrant is necessary to transfer encrypted EBS
             # resources across regions.
             'kms:CreateGrant'
         ],

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -567,7 +567,10 @@ class AWSAccount:
         'Action': [
             'kms:Encrypt',
             'kms:Decrypt',
-            'kms:ReEncrypt*'
+            'kms:ReEncrypt*',
+            # This permission is necessary to transfer encrypted EBS
+            # resources across regions.
+            'kms:CreateGrant'
         ],
         'Resource': '*'
     }

--- a/libcloudforensics/providers/aws/internal/ebs.py
+++ b/libcloudforensics/providers/aws/internal/ebs.py
@@ -236,8 +236,7 @@ class AWSSnapshot(AWSElasticBlockStore):
           self.snapshot_id, str(exception)))
 
     snapshot_copy = AWSSnapshot(
-        # If the call above was successful, the response contains the new
-        # snapshot ID
+        # The response contains the new snapshot ID
         response['SnapshotId'],
         self.aws_account,
         self.aws_account.default_region,

--- a/tests/providers/aws/aws_test.py
+++ b/tests/providers/aws/aws_test.py
@@ -51,6 +51,9 @@ FAKE_BOOT_VOLUME = ebs.AWSVolume(
     device_name='/dev/spf')
 FAKE_SNAPSHOT = ebs.AWSSnapshot(
     'fake-snapshot-id',
+    FAKE_AWS_ACCOUNT,
+    'fake-zone-2',
+    'fake-zone-2b',
     FAKE_VOLUME,
     name='fake-snapshot')
 FAKE_CLOUDTRAIL = aws_log.AWSCloudTrail(FAKE_AWS_ACCOUNT)


### PR DESCRIPTION
Closes #86 

E.g usage: 

```
python -m examples.libcloudforensics aws us-west-1a copydisk --dst_zone us-east-2c --volume_id vol-xxx
```

Signed-off-by: Theo Giovanna <gtheo@google.com>