### PR TITLE
Add SSH key option to StartAnalysisVm()

### DIFF
--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -180,9 +180,10 @@ def StartAnalysisVm(vm_name,
     ssh_key_name (str): Optional. A SSH key pair name linked to the AWS
         account to associate with the VM. If none provided, the VM can only
         be accessed through in-browser SSH from the AWS management console
-        with the EC2 client connection package. Note that if this package
-        fails to install on the target VM, then the VM will not be accessible.
-        It is therefore recommended to fill in this parameter.
+        with the EC2 client connection package (ec2-instance-connect). Note
+        that if this package fails to install on the target VM, then the VM
+        will not be accessible. It is therefore recommended to fill in this
+        parameter.
 
   Returns:
     tuple(AWSInstance, bool): a tuple with a virtual machine object
@@ -193,11 +194,12 @@ def StartAnalysisVm(vm_name,
   """
   aws_account = account.AWSAccount(
       default_availability_zone, aws_profile=dst_account)
-  analysis_vm, created = aws_account.GetOrCreateAnalysisVm(vm_name,
-                                                           boot_volume_size,
-                                                           ami,
-                                                           cpu_cores,
-                                                           ssh_key_name=ssh_key_name)  # pylint: disable=line-too-long
+  analysis_vm, created = aws_account.GetOrCreateAnalysisVm(
+      vm_name,
+      boot_volume_size,
+      ami,
+      cpu_cores,
+      ssh_key_name=ssh_key_name)
   if attach_volume:
     if not device_name:
       raise RuntimeError('If you want to attach a volume, you must also '

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -150,11 +150,12 @@ def CreateVolumeCopy(zone,
 def StartAnalysisVm(vm_name,
                     default_availability_zone,
                     boot_volume_size,
-                    cpu_cores=4,
                     ami=UBUNTU_1804_AMI,
+                    cpu_cores=4,
                     attach_volume=None,
                     device_name=None,
-                    dst_account=None):
+                    dst_account=None,
+                    ssh_key_name=None):
   """Start a virtual machine for analysis purposes.
 
   Look for an existing AWS instance with tag name vm_name. If found,
@@ -166,16 +167,22 @@ def StartAnalysisVm(vm_name,
     default_availability_zone (str): Default zone within the region to create
         new resources in.
     boot_volume_size (int): The size of the analysis VM boot volume (in GB).
-    cpu_cores (int): Optional. The number of CPU cores to create the machine
-        with. Default is 4.
     ami (str): Optional. The Amazon Machine Image ID to use to create the VM.
         Default is a version of Ubuntu 18.04.
+    cpu_cores (int): Optional. The number of CPU cores to create the machine
+        with. Default is 4.
     attach_volume (AWSVolume): Optional. The volume to attach.
     device_name (str): Optional. The name of the device (e.g. /dev/sdf) for
         the volume to be attached. Mandatory if attach_volume is provided.
     dst_account (str): Optional. The AWS account in which to create the
         analysis VM. This is the profile name that is defined in your AWS
         credentials file.
+    ssh_key_name (str): Optional. A SSH key pair name linked to the AWS
+        account to associate with the VM. If none provided, the VM can only
+        be accessed through in-browser SSH from the AWS management console
+        with the EC2 client connection package. Note that if this package
+        fails to install on the target VM, then the VM will not be accessible.
+        It is therefore recommended to fill in this parameter.
 
   Returns:
     tuple(AWSInstance, bool): a tuple with a virtual machine object
@@ -186,8 +193,11 @@ def StartAnalysisVm(vm_name,
   """
   aws_account = account.AWSAccount(
       default_availability_zone, aws_profile=dst_account)
-  analysis_vm, created = aws_account.GetOrCreateAnalysisVm(
-      vm_name, boot_volume_size, cpu_cores=cpu_cores, ami=ami)
+  analysis_vm, created = aws_account.GetOrCreateAnalysisVm(vm_name,
+                                                           boot_volume_size,
+                                                           ami,
+                                                           cpu_cores,
+                                                           ssh_key_name=ssh_key_name)  # pylint: disable=line-too-long
   if attach_volume:
     if not device_name:
       raise RuntimeError('If you want to attach a volume, you must also '

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -499,7 +499,8 @@ class AWSAccount:
       client.get_waiter('instance_running').wait(InstanceIds=[instance_id])
       # Wait for the status checks to pass
       client.get_waiter('instance_status_ok').wait(InstanceIds=[instance_id])
-    except client.exceptions.ClientError as exception:
+    except (client.exceptions.ClientError,
+            botocore.exceptions.WaiterError) as exception:
       raise RuntimeError('Could not create instance {0:s}: {1:s}'.format(
           vm_name, str(exception)))
 

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -441,9 +441,10 @@ class AWSAccount:
       ssh_key_name (str): Optional. A SSH key pair name linked to the AWS
           account to associate with the VM. If none provided, the VM can only
           be accessed through in-browser SSH from the AWS management console
-          with the EC2 client connection package. Note that if this package
-          fails to install on the target VM, then the VM will not be accessible.
-          It is therefore recommended to fill in this parameter.
+          with the EC2 client connection package (ec2-instance-connect). Note
+          that if this package fails to install on the target VM, then the VM
+          will not be accessible. It is therefore recommended to fill in this
+          parameter.
 
     Returns:
       tuple(AWSInstance, bool): A tuple with an AWSInstance object and a

--- a/tests/providers/aws/aws_e2e.py
+++ b/tests/providers/aws/aws_e2e.py
@@ -119,11 +119,12 @@ class EndToEndTest(unittest.TestCase):
         volume_id=self.volume_to_forensic)
     self.volumes.append(volume_to_attach)
     # Create and start the analysis VM and attach the boot volume
-    self.analysis_vm, _ = forensics.StartAnalysisVm(self.analysis_vm_name,
-                                                    self.zone,
-                                                    10,
-                                                    attach_volume=volume_to_attach,  # pylint: disable=line-too-long
-                                                    device_name='/dev/sdp')
+    self.analysis_vm, _ = forensics.StartAnalysisVm(
+        self.analysis_vm_name,
+        self.zone,
+        10,
+        attach_volume=volume_to_attach,
+        device_name='/dev/sdp')
 
     # The forensic instance should be live in the analysis AWS account and
     # the volume should be attached

--- a/tests/providers/aws/aws_e2e.py
+++ b/tests/providers/aws/aws_e2e.py
@@ -57,8 +57,9 @@ class EndToEndTest(unittest.TestCase):
     cls.volume_to_forensic = project_info.get('volume_id', None)
     cls.aws = account.AWSAccount(cls.zone)
     cls.analysis_vm_name = 'new-vm-for-analysis'
-    cls.analysis_vm, _ = forensics.StartAnalysisVm(
-        cls.analysis_vm_name, cls.zone, 10, 4)
+    cls.analysis_vm, _ = forensics.StartAnalysisVm(cls.analysis_vm_name,
+                                                   cls.zone,
+                                                   10)
     cls.volumes = []
 
   def test_end_to_end_boot_volume(self):
@@ -118,14 +119,11 @@ class EndToEndTest(unittest.TestCase):
         volume_id=self.volume_to_forensic)
     self.volumes.append(volume_to_attach)
     # Create and start the analysis VM and attach the boot volume
-    self.analysis_vm, _ = forensics.StartAnalysisVm(
-        self.analysis_vm_name,
-        self.zone,
-        10,
-        4,
-        attach_volume=volume_to_attach,
-        device_name='/dev/sdp'
-    )
+    self.analysis_vm, _ = forensics.StartAnalysisVm(self.analysis_vm_name,
+                                                    self.zone,
+                                                    10,
+                                                    attach_volume=volume_to_attach,  # pylint: disable=line-too-long
+                                                    device_name='/dev/sdp')
 
     # The forensic instance should be live in the analysis AWS account and
     # the volume should be attached


### PR DESCRIPTION
Allows users to associate a SSH key pair name to VMs created by the library. If in-browser SSH connexion fails, then users can access the VM through regular SSH.

Closes #87 

Signed-off-by: Theo Giovanna <gtheo@google.com>