### PR TITLE
Change return type of GoogleComputeInstance.ListDisks()

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -524,10 +524,16 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     """List all disks for the virtual machine.
 
     Returns:
-      list(str): List of disk names.
+      Dict[str, GoogleComputeDisk]: Dictionary mapping disk names to their
+          respective GoogleComputeDisk object.
     """
 
-    return [disk['source'].split('/')[-1] for disk in self.GetValue('disks')]
+    disks = {}
+    disk_names = [disk['source'].split('/')[-1] for disk in self.GetValue(
+        'disks')]
+    for name in disk_names:
+      disks[name] = self.GetDisk(name)
+    return disks
 
   def __SshConnection(self):
     """Create an SSH connection to the virtual machine."""

--- a/tests/providers/gcp/gcp_e2e.py
+++ b/tests/providers/gcp/gcp_e2e.py
@@ -219,7 +219,7 @@ class EndToEndTest(unittest.TestCase):
     # delete the copied disks
     # we ignore the disk that was created for the analysis VM (disks[0]) as
     # it is deleted in the previous operation
-    for disk in disks[1:]:
+    for disk in list(disks.keys())[1:]:
       common.LOGGER.info('Deleting disk: {0:s}.'.format(disk))
       while True:
         try:

--- a/tests/providers/gcp/gcp_test.py
+++ b/tests/providers/gcp/gcp_test.py
@@ -483,7 +483,7 @@ class GoogleComputeInstanceTest(unittest.TestCase):
 
     disks = FAKE_INSTANCE.ListDisks()
     self.assertEqual(2, len(disks))
-    self.assertEqual(['fake-boot-disk', 'fake-disk'], disks)
+    self.assertEqual(['fake-boot-disk', 'fake-disk'], list(disks.keys()))
 
 
 class GoogleComputeDiskTest(unittest.TestCase):


### PR DESCRIPTION
To be more consistent with the `ListDisks()` method in the `compute` module.

Signed-off-by: Theo Giovanna <gtheo@google.com>