### PR TITLE
Add GCP API 'body' request field check

### DIFF
--- a/examples/libcloudforensics.py
+++ b/examples/libcloudforensics.py
@@ -132,9 +132,9 @@ def Main() -> None:
             'List GCE disks in GCP project.')
   AddParser('gcp', gcp_subparsers, 'copydisk', 'Create a GCP disk copy.',
             args=[
-                ('dstproject', 'Destination GCP project.', ''),
-                ('instancename', 'Name of the instance to copy disk from.', ''),
-                ('zone', 'Zone to create the disk in.', '')
+                ('--dstproject', 'Destination GCP project.', ''),
+                ('--instancename', 'Name of the instance to copy disk from.', ''),
+                ('--zone', 'Zone to create the disk in.', '')
             ])
   AddParser('gcp', gcp_subparsers, 'querylogs', 'Query GCP logs.',
             args=[

--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -232,7 +232,11 @@ def ExecuteRequest(client: 'googleapiclient.discovery.Resource',
     if throttle:
       time.sleep(1)
     if next_token:
-      kwargs['pageToken'] = next_token
+      # Some API calls use a body field for the request.
+      if 'body' in kwargs:
+        kwargs['body']['pageToken'] = next_token
+      else:
+        kwargs['pageToken'] = next_token
     try:
       request = getattr(client, func)
       response = request(**kwargs).execute()

--- a/libcloudforensics/providers/gcp/internal/log.py
+++ b/libcloudforensics/providers/gcp/internal/log.py
@@ -99,9 +99,11 @@ class GoogleCloudLog:
     """
 
     body = {
+      'body': {
         'resourceNames': 'projects/' + self.project_id,
         'filter': qfilter,
         'orderBy': 'timestamp desc',
+      }
     }
 
     entries = []


### PR DESCRIPTION
Some GCP API calls (unknown from discovery service which ones...) expect the request to be in a 'body' field. 