### PR TITLE
Add code for API calls that expect the 'body' request field

### DIFF
--- a/examples/libcloudforensics.py
+++ b/examples/libcloudforensics.py
@@ -132,9 +132,9 @@ def Main() -> None:
             'List GCE disks in GCP project.')
   AddParser('gcp', gcp_subparsers, 'copydisk', 'Create a GCP disk copy.',
             args=[
-                ('dstproject', 'Destination GCP project.', ''),
-                ('instancename', 'Name of the instance to copy disk from.', ''),
-                ('zone', 'Zone to create the disk in.', '')
+                ('--dstproject', 'Destination GCP project.', ''),
+                ('--instancename', 'Name of the instance to copy disk from.', ''),
+                ('--zone', 'Zone to create the disk in.', '')
             ])
   AddParser('gcp', gcp_subparsers, 'querylogs', 'Query GCP logs.',
             args=[

--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -232,7 +232,10 @@ def ExecuteRequest(client: 'googleapiclient.discovery.Resource',
     if throttle:
       time.sleep(1)
     if next_token:
-      kwargs['pageToken'] = next_token
+      if 'body' in kwargs:
+        kwargs['body']['pageToken'] = next_token
+      else:
+        kwargs['pageToken'] = next_token
     try:
       request = getattr(client, func)
       response = request(**kwargs).execute()

--- a/libcloudforensics/providers/gcp/internal/log.py
+++ b/libcloudforensics/providers/gcp/internal/log.py
@@ -107,7 +107,7 @@ class GoogleCloudLog:
     entries = []
     gcl_instance_client = self.GclApi().entries()
     responses = common.ExecuteRequest(
-        gcl_instance_client, 'list', body, throttle=True)
+        gcl_instance_client, 'list', {'body': body}, throttle=True)
 
     for response in responses:
       for entry in response.get('entries', []):


### PR DESCRIPTION
Some google cloud apis expect the request to be in a 'body' field. From the discovery api it is unclear which calls are expecting those. 