### PR TITLE
Add 'body' request field if GCP API needs them.

### DIFF
--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -232,7 +232,10 @@ def ExecuteRequest(client: 'googleapiclient.discovery.Resource',
     if throttle:
       time.sleep(1)
     if next_token:
-      kwargs['pageToken'] = next_token
+      if 'body' in kwargs:
+        kwargs['pageToken'] = next_token
+      else:
+         kwargs['pageToken'] = next_token
     try:
       request = getattr(client, func)
       response = request(**kwargs).execute()

--- a/libcloudforensics/providers/gcp/internal/log.py
+++ b/libcloudforensics/providers/gcp/internal/log.py
@@ -107,7 +107,7 @@ class GoogleCloudLog:
     entries = []
     gcl_instance_client = self.GclApi().entries()
     responses = common.ExecuteRequest(
-        gcl_instance_client, 'list', body, throttle=True)
+        gcl_instance_client, 'list', {'body': body}, throttle=True)
 
     for response in responses:
       for entry in response.get('entries', []):


### PR DESCRIPTION
Some google cloud apis expect the request to be in a 'body' field. From the discovery api it is unclear which calls are expecting those. 

This PR
* fixes execute query API call
* takes care of nextpage token