### PR TITLE
Add AMI ListImages to AWS API

### DIFF
--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -20,7 +20,7 @@
 import json
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING
 
 from libcloudforensics.providers.aws.internal import account
 from libcloudforensics.providers.aws.internal import log as aws_log
@@ -156,9 +156,9 @@ def ListImages(args: 'argparse.Namespace') -> None:
   """
   aws_account = account.AWSAccount(args.zone)
 
-  filter = [{'Name':'name','Values':[args.filter]}]
+  qfilter = [{'Name':'name', 'Values':[args.filter]}]
 
-  images = aws_account.ListImages(filter)
+  images = aws_account.ListImages(qfilter)
 
   for image in images:
     print('Name: {0:s}, ImageId: {1:s}'.format(image['Name'],

--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -20,7 +20,7 @@
 import json
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from libcloudforensics.providers.aws.internal import account
 from libcloudforensics.providers.aws.internal import log as aws_log
@@ -147,3 +147,19 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
   print('Name: {0:s}, Started: {1:s}, Region: {2:s}'.format(vm[0].name,
                                                             str(vm[1]),
                                                             vm[0].region))
+
+def ListImages(args: 'argparse.Namespace') -> None:
+  """List AMI images and filter on AMI image 'name'.
+
+  Args:
+    args (argparse.Namespace): Arguments from ArgumentParser.
+  """
+  aws_account = account.AWSAccount(args.zone)
+
+  filter = [{'Name':'name','Values':[args.filter]}]
+
+  images = aws_account.ListImages(filter)
+
+  for image in images:
+    print('Name: {0:s}, ImageId: {1:s}'.format(image['Name'],
+                                               image['ImageId']))

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -25,6 +25,7 @@ from examples import aws_cli, gcp_cli
 PROVIDER_TO_FUNC = {
     'aws': {
         'copydisk': aws_cli.CreateVolumeCopy,
+        'listimages': aws_cli.ListImages,
         'listinstances': aws_cli.ListInstances,
         'listdisks': aws_cli.ListVolumes,
         'querylogs': aws_cli.QueryLogs,
@@ -133,6 +134,10 @@ def Main() -> None:
                 ('--ssh_key_name', 'SSH key pair name.', None),
                 ('--attach_volumes', 'Comma seperated list of volume IDs '
                                      'to attach. Maximum of 11.', None)
+            ])
+  AddParser('aws', aws_subparsers, 'listimages', 'List AMI images.',
+            args=[
+                ('--filter', 'Filter to apply to Name of AMI image.', None),
             ])
 
   # GCP parser options

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -19,7 +19,7 @@
 import argparse
 import sys
 
-from typing import Tuple, List, Union, Optional
+from typing import Tuple, List, Optional
 from examples import aws_cli, gcp_cli
 
 PROVIDER_TO_FUNC = {

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -746,7 +746,7 @@ class AWSAccount:
     return block_device_mapping
 
   def ListImages(self,
-                 qfilter: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+                 qfilter: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
     """List AMI images.
 
     Args:

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -746,11 +746,11 @@ class AWSAccount:
     return block_device_mapping
 
   def ListImages(self,
-                 filter: str) -> List[Dict[str, Any]]:
+                 qfilter: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """List AMI images.
 
     Args:
-      filter (List[Dict]): The filter expression.
+      qfilter (List[Dict): The filter expression.
       See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_images  # pylint: disable=line-too-long
 
     Returns:
@@ -762,7 +762,7 @@ class AWSAccount:
 
     client = self.ClientApi(common.EC2_SERVICE)
     try:
-      images = client.describe_images(Filters=filter)
+      images = client.describe_images(Filters=qfilter)
     except client.exceptions.ClientError as exception:
       raise RuntimeError(str(exception))
 

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -20,7 +20,7 @@ analysis virtual machine to be used in incident response.
 
 import binascii
 import json
-from typing import Dict, List, Tuple, Optional, Any, cast
+from typing import Dict, List, Tuple, Optional, Any
 
 import boto3
 import botocore
@@ -745,8 +745,9 @@ class AWSAccount:
     block_device_mapping['Ebs']['VolumeSize'] = boot_volume_size
     return block_device_mapping
 
+  # pylint: disable=line-too-long
   def ListImages(self,
-                 qfilter: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:  # pylint: disable=line-too-long
+                 qfilter: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
     """List AMI images.
 
     Args:
@@ -762,8 +763,9 @@ class AWSAccount:
 
     client = self.ClientApi(common.EC2_SERVICE)
     try:
-      images = client.describe_images(Filters=qfilter)
+      images = client.describe_images(Filters=qfilter) # type: Dict[str, List[Dict[str, Any]]]
     except client.exceptions.ClientError as exception:
       raise RuntimeError(str(exception))
 
-    return cast(List[Dict[str, Any]], images['Images'])
+    return images['Images']
+  # pylint: enable=line-too-long

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -744,3 +744,26 @@ class AWSAccount:
     # pylint: enable=line-too-long
     block_device_mapping['Ebs']['VolumeSize'] = boot_volume_size
     return block_device_mapping
+
+  def ListImages(self,
+                 filter: str) -> List[Dict[str, Any]]:
+    """List AMI images.
+
+    Args:
+      filter (List[Dict]): The filter expression.
+      See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_images  # pylint: disable=line-too-long
+
+    Returns:
+      List[Dict[str, Any]]: The list of images with their properties.
+
+    Raises:
+      RuntimeError: If the images could not be listed.
+    """
+
+    client = self.ClientApi(common.EC2_SERVICE)
+    try:
+      images = client.describe_images(Filters=filter)
+    except client.exceptions.ClientError as exception:
+      raise RuntimeError(str(exception))
+
+    return images['Images']

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -20,7 +20,7 @@ analysis virtual machine to be used in incident response.
 
 import binascii
 import json
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Dict, List, Tuple, Optional, Any, cast
 
 import boto3
 import botocore
@@ -766,4 +766,4 @@ class AWSAccount:
     except client.exceptions.ClientError as exception:
       raise RuntimeError(str(exception))
 
-    return images['Images']
+    return cast(List[Dict[str, Any]], images['Images'])

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -746,7 +746,7 @@ class AWSAccount:
     return block_device_mapping
 
   def ListImages(self,
-                 qfilter: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+                 qfilter: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:  # pylint: disable=line-too-long
     """List AMI images.
 
     Args:

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -751,7 +751,7 @@ class AWSAccount:
     """List AMI images.
 
     Args:
-      qfilter (List[Dict): The filter expression.
+      qfilter (List[Dict]): The filter expression.
       See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_images  # pylint: disable=line-too-long
 
     Returns:

--- a/tests/providers/aws/aws_e2e.py
+++ b/tests/providers/aws/aws_e2e.py
@@ -117,6 +117,20 @@ class EndToEndTest(unittest.TestCase):
     self._StoreVolumeForCleanup(aws_account, aws_volume)
 
   @typing.no_type_check
+  def testListImages(self):
+    """End to end test on AWS.
+
+    Test listing AMI images with a filter.
+    """
+
+    aws_account = account.AWSAccount(self.zone)
+    qfilter = [{'Name':'name', 'Values':['Ubuntu 18.04*']}]
+    images = aws_account.ListImages(qfilter)
+
+    self.assertGreater(len(images), 0)
+    self.assertIn('Name', images[0])
+
+  @typing.no_type_check
   def testEncryptedVolumeCopy(self):
     """End to end test on AWS.
 

--- a/tests/providers/aws/aws_test.py
+++ b/tests/providers/aws/aws_test.py
@@ -96,6 +96,13 @@ MOCK_DESCRIBE_INSTANCES_TAGS = {
     }]
 }
 
+MOCK_DESCRIBE_IMAGES = {
+    'Images' : [
+        {'Name': 'Ubuntu 18.04 LTS', 'Public': True},
+        {'Name': 'Ubuntu 18.04 with GUI', 'Public': False}
+    ]
+}
+
 MOCK_DESCRIBE_VOLUMES = {
     'Volumes': [{
         'VolumeId': FAKE_VOLUME.volume_id,
@@ -425,6 +432,15 @@ class AWSAccountTest(unittest.TestCase):
     # pylint: enable=protected-access
     self.assertEqual(50, config['Ebs']['VolumeSize'])
 
+  @typing.no_type_check
+  @mock.patch('libcloudforensics.providers.aws.internal.account.AWSAccount.ClientApi')
+  def testListImages(self, mock_ec2_api):
+    """Test that AMI images are correctly listed."""
+    describe_images = mock_ec2_api.return_value.describe_images
+    describe_images.return_value = MOCK_DESCRIBE_IMAGES
+    images = FAKE_AWS_ACCOUNT.ListImages(qfilter=None)
+    self.assertEqual(2, len(images))
+    self.assertIn('Name', images[0])
 
 class AWSInstanceTest(unittest.TestCase):
   """Test AWSInstance class."""


### PR DESCRIPTION
This function allows us to list AMI images based on a filter.

Implemented filtering on 'name' in CLI tool:
```
$ libcloudforensics aws eu-central-1b listimages --filter 'Ubuntu 18*'
Name: Ubuntu 18 with GUI-8920beb5-58cf-4d42-9796-d6001abca657-ami-02a81703881728e32.4, ImageId: ami-019900387055900b8
Name: Ubuntu 18.04 LTS x86_64-b5e89a5e-1653-4f64-97df-45904c7427ad-ami-0d50f1fc86520b33d.4, ImageId: ami-0ac1862d96bbc1863
```

Filter expression syntax -> https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_images

This function is needed to fix #159 