### PR TITLE
Make StartVm pick right AMI per zone.

### DIFF
--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -115,7 +115,7 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
   Args:
     args (argparse.Namespace): Arguments from ArgumentParser.
   """
-  if len(args.attach_volumes) > 11:
+  if args.attach_volumes and len(args.attach_volumes) > 11:
     print('error: --attach_volumes must be < 11')
     return
 
@@ -140,6 +140,7 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
                                  default_availability_zone=args.zone,
                                  boot_volume_size=int(args.disk_size),
                                  cpu_cores=int(args.cpu_cores),
+                                 ami=args.ami,
                                  ssh_key_name=args.ssh_key_name,
                                  attach_volumes=attach_volumes)
 
@@ -161,5 +162,6 @@ def ListImages(args: 'argparse.Namespace') -> None:
   images = aws_account.ListImages(qfilter)
 
   for image in images:
-    print('Name: {0:s}, ImageId: {1:s}'.format(image['Name'],
-                                               image['ImageId']))
+    print('Name: {0:s}, ImageId: {1:s}, '
+          'Location: {2:s}'.format(image['Name'], image['ImageId'],
+                                   image['ImageLocation']))

--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -162,6 +162,5 @@ def ListImages(args: 'argparse.Namespace') -> None:
   images = aws_account.ListImages(qfilter)
 
   for image in images:
-    print('Name: {0:s}, ImageId: {1:s}, '
-          'Location: {2:s}'.format(image['Name'], image['ImageId'],
-                                   image['ImageLocation']))
+    print('Name: {0:s}, ImageId: {1:s}, Location: {2:s}'.format(
+        image['Name'], image['ImageId'], image['ImageLocation']))

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -131,6 +131,9 @@ def Main() -> None:
                  ''),
                 ('--disk_size', 'Size of disk in GB.', '50'),
                 ('--cpu_cores', 'Instance CPU core count.', '4'),
+                ('--ami', 'AMI ID to use as base image. Will search '
+                          'Ubuntu 18.04 LTS server x86_64 for chosen region '
+                          'by default.', ''),
                 ('--ssh_key_name', 'SSH key pair name.', None),
                 ('--attach_volumes', 'Comma seperated list of volume IDs '
                                      'to attach. Maximum of 11.', None)

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -222,8 +222,9 @@ def StartAnalysisVm(
     # We should only get 1 AMI image back, if we get multiple we
     # have no way of knowing which one to use.
     if len(ami_list) > 1:
+      image_names = [image['Name'] for image in ami_list]
       raise RuntimeError('error - ListImages returns >1 AMI image: [{0:s}]'
-                         .format(', '.join([image['Name'] for image in ami_list]))) # pylint: disable=line-too-long
+                         .format(', '.join(image_names)))
     ami = ami_list[0]['ImageId']
 
   analysis_vm, created = aws_account.GetOrCreateAnalysisVm(

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -208,8 +208,7 @@ def StartAnalysisVm(
         and a boolean indicating if the virtual machine was created or not.
 
   Raises:
-    RuntimeError: If the requested provider or function is not
-        implemented.
+    RuntimeError: When multiple AMI images are returned.
   """
 
   aws_account = account.AWSAccount(
@@ -220,6 +219,8 @@ def StartAnalysisVm(
   if not ami:
     qfilter = [{'Name':'name', 'Values':[UBUNTU_1804_FILTER]}]
     ami_list = aws_account.ListImages(qfilter)
+    # We should only het 1 AMI image back, if we get multiple we
+    # have no way of knowing which one to use.
     if len(ami_list) > 1:
       raise RuntimeError('error - ListImages returns >1 AMI image!')
     ami = ami_list[0]['ImageId']

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -222,6 +222,10 @@ def StartAnalysisVm(
     # We should only get 1 AMI image back, if we get multiple we
     # have no way of knowing which one to use.
     if len(ami_list) > 1:
+      print('AMI images found:')
+      for image in ami_list:
+        print('Name: {0:s}, ImageId: {1:s}, Location: {2:s}'.format(
+            image['Name'], image['ImageId'], image['ImageLocation']))
       raise RuntimeError('error - ListImages returns >1 AMI image!')
     ami = ami_list[0]['ImageId']
 

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -217,7 +217,7 @@ def StartAnalysisVm(
   # If no AMI ID is given we use the default Ubuntu 18.04
   # in the region requested.
   if not ami:
-    qfilter = [{'Name':'name', 'Values':[UBUNTU_1804_FILTER]}]
+    qfilter = [{'Name': 'name', 'Values': [UBUNTU_1804_FILTER]}]
     ami_list = aws_account.ListImages(qfilter)
     # We should only get 1 AMI image back, if we get multiple we
     # have no way of knowing which one to use.

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -219,7 +219,7 @@ def StartAnalysisVm(
   if not ami:
     qfilter = [{'Name':'name', 'Values':[UBUNTU_1804_FILTER]}]
     ami_list = aws_account.ListImages(qfilter)
-    # We should only het 1 AMI image back, if we get multiple we
+    # We should only get 1 AMI image back, if we get multiple we
     # have no way of knowing which one to use.
     if len(ami_list) > 1:
       raise RuntimeError('error - ListImages returns >1 AMI image!')

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Forensics on AWS."""
-from typing import TYPE_CHECKING, Tuple, List, Optional, Dict, Any
+from typing import TYPE_CHECKING, Tuple, List, Optional, Dict
 
-from libcloudforensics.providers.aws.internal.common import UBUNTU_1804_AMI, LOGGER  # pylint: disable=line-too-long
+from libcloudforensics.providers.aws.internal.common import UBUNTU_1804_FILTER, LOGGER  # pylint: disable=line-too-long
 from libcloudforensics.providers.aws.internal import account
 
 if TYPE_CHECKING:
@@ -164,7 +164,7 @@ def StartAnalysisVm(
     vm_name: str,
     default_availability_zone: str,
     boot_volume_size: int,
-    ami: str = UBUNTU_1804_AMI,
+    ami: str = '',
     cpu_cores: int = 4,
     attach_volumes: Optional[List[Tuple[str, str]]] = None,
     dst_profile: Optional[str] = None,
@@ -206,9 +206,24 @@ def StartAnalysisVm(
   Returns:
     Tuple[AWSInstance, bool]: a tuple with a virtual machine object
         and a boolean indicating if the virtual machine was created or not.
+
+  Raises:
+    RuntimeError: If the requested provider or function is not
+        implemented.
   """
+
   aws_account = account.AWSAccount(
       default_availability_zone, aws_profile=dst_profile)
+
+  # If no AMI ID is given we use the default Ubuntu 18.04
+  # in the region requested.
+  if not ami:
+    qfilter = [{'Name':'name', 'Values':[UBUNTU_1804_FILTER]}]
+    ami_list = aws_account.ListImages(qfilter)
+    if len(ami_list) > 1:
+      raise RuntimeError('error - ListImages returns >1 AMI image!')
+    ami = ami_list[0]['ImageId']
+
   analysis_vm, created = aws_account.GetOrCreateAnalysisVm(
       vm_name,
       boot_volume_size,

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -222,11 +222,8 @@ def StartAnalysisVm(
     # We should only get 1 AMI image back, if we get multiple we
     # have no way of knowing which one to use.
     if len(ami_list) > 1:
-      print('AMI images found:')
-      for image in ami_list:
-        print('Name: {0:s}, ImageId: {1:s}, Location: {2:s}'.format(
-            image['Name'], image['ImageId'], image['ImageLocation']))
-      raise RuntimeError('error - ListImages returns >1 AMI image!')
+      raise RuntimeError('error - ListImages returns >1 AMI image: [{0:s}]'
+                         .format(', '.join([image['Name'] for image in ami_list]))) # pylint: disable=line-too-long
     ami = ami_list[0]['ImageId']
 
   analysis_vm, created = aws_account.GetOrCreateAnalysisVm(

--- a/libcloudforensics/providers/aws/internal/common.py
+++ b/libcloudforensics/providers/aws/internal/common.py
@@ -31,7 +31,7 @@ VOLUME = 'volume'
 SNAPSHOT = 'snapshot'
 
 # Default Amazon Machine Image to use for bootstrapping instances
-UBUNTU_1804_FILTER = 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200611'  #pylint: disable=line-too-long
+UBUNTU_1804_FILTER = 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200611'  # pylint: disable=line-too-long
 REGEX_TAG_VALUE = re.compile('^.{1,255}$')
 
 LOGGER = logging.getLogger()

--- a/libcloudforensics/providers/aws/internal/common.py
+++ b/libcloudforensics/providers/aws/internal/common.py
@@ -31,7 +31,7 @@ VOLUME = 'volume'
 SNAPSHOT = 'snapshot'
 
 # Default Amazon Machine Image to use for bootstrapping instances
-UBUNTU_1804_AMI = 'ami-0013b3aa57f8a4331'
+UBUNTU_1804_FILTER = 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200611'  #pylint: disable=line-too-long
 REGEX_TAG_VALUE = re.compile('^.{1,255}$')
 
 LOGGER = logging.getLogger()


### PR DESCRIPTION
AWS StartAnalysisVM can now be started in any zone and picks the correct AMI.

Extra:
* added parameter to choose the base AMI so people can create customised Analysis VMs.
* small attach_volumes fix

Fixes #159 