### PR TITLE
Add CLI for Azure snapshotting capabilities

### DIFF
--- a/examples/az_cli.py
+++ b/examples/az_cli.py
@@ -35,8 +35,8 @@ def ListInstances(args: 'argparse.Namespace') -> None:
       resource_group_name=args.resource_group_name)
 
   print('Instances found:')
-  for instance in instances:
-    boot_disk = instances[instance].GetBootDisk().name
+  for instance in instances.values():
+    boot_disk = instance.GetBootDisk().name
     print('Name: {0:s}, Boot disk: {1:s}'.format(instance, boot_disk))
 
 

--- a/examples/az_cli.py
+++ b/examples/az_cli.py
@@ -13,3 +13,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Demo CLI tool for Azure."""
+
+from typing import TYPE_CHECKING
+
+from libcloudforensics.providers.azure.internal import account
+from libcloudforensics.providers.azure import forensics
+
+if TYPE_CHECKING:
+  import argparse
+
+
+def ListInstances(args: 'argparse.Namespace') -> None:
+  """List instances in Azure subscription.
+
+  Args:
+    args (argparse.Namespace): Arguments from ArgumentParser.
+  """
+
+  az_account = account.AZAccount(args.subscription_id)
+  instances = az_account.ListInstances(
+      resource_group_name=args.resource_group_name)
+
+  print('Instances found:')
+  for instance in instances:
+    boot_disk = instances[instance].GetBootDisk().name
+    print('Name: {0:s}, Boot disk: {1:s}'.format(instance, boot_disk))
+
+
+def ListDisks(args: 'argparse.Namespace') -> None:
+  """List disks in Azure subscription.
+
+  Args:
+    args (argparse.Namespace): Arguments from ArgumentParser.
+  """
+
+  az_account = account.AZAccount(args.subscription_id)
+  disks = az_account.ListDisks(resource_group_name=args.resource_group_name)
+
+  print('Disks found:')
+  for disk in disks:
+    print('Name: {0:s}, Region: {1:s}'.format(disk, disks[disk].region))
+
+
+def CreateDiskCopy(args: 'argparse.Namespace') -> None:
+  """Create an Azure disk copy.
+
+  Args:
+    args (argparse.Namespace): Arguments from ArgumentParser.
+  """
+  print('Starting disk copy...')
+  disk_copy = forensics.CreateDiskCopy(args.subscription_id,
+                                       args.instance_name,
+                                       args.disk_name,
+                                       args.disk_type)
+  print('Done! Disk {0:s} successfully created.'.format(disk_copy.name))

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -170,8 +170,8 @@ def Main() -> None:
   AddParser('az', az_subparsers, 'listdisks',
             'List disks in Azure subscription.',
             args=[
-              ('--resource_group_name', 'The resource group name from '
-                                        'which to list disks.', None)
+                ('--resource_group_name', 'The resource group name from '
+                                          'which to list disks.', None)
             ])
   AddParser('az', az_subparsers, 'copydisk', 'Create an Azure disk copy.',
             args=[

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -176,7 +176,7 @@ def Main() -> None:
   AddParser('az', az_subparsers, 'copydisk', 'Create an Azure disk copy.',
             args=[
                 ('--instance_name', 'The instance name.', None),
-                ('--disk_name', 'The disk name of the disk to copy. If none '
+                ('--disk_name', 'The name of the disk to copy. If none '
                                 'specified, then --instance_name must be '
                                 'specified and the boot disk of the Azure '
                                 'instance will be copied.', None),

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -20,7 +20,7 @@ import argparse
 import sys
 
 from typing import Tuple, List, Optional
-from examples import aws_cli, gcp_cli
+from examples import aws_cli, az_cli, gcp_cli
 
 PROVIDER_TO_FUNC = {
     'aws': {
@@ -30,6 +30,11 @@ PROVIDER_TO_FUNC = {
         'listdisks': aws_cli.ListVolumes,
         'querylogs': aws_cli.QueryLogs,
         'startvm': aws_cli.StartAnalysisVm
+    },
+    'az': {
+        'copydisk': az_cli.CreateDiskCopy,
+        'listinstances': az_cli.ListInstances,
+        'listdisks': az_cli.ListDisks
     },
     'gcp': {
         'copydisk': gcp_cli.CreateDiskCopy,
@@ -95,6 +100,7 @@ def Main() -> None:
   subparsers = parser.add_subparsers()
 
   aws_parser = subparsers.add_parser('aws', help='Tools for AWS')
+  az_parser = subparsers.add_parser('az', help='Tools for Azure')
   gcp_parser = subparsers.add_parser('gcp', help='Tools for GCP')
 
   # AWS parser options
@@ -150,6 +156,34 @@ def Main() -> None:
   AddParser('aws', aws_subparsers, 'listimages', 'List AMI images.',
             args=[
                 ('--filter', 'Filter to apply to Name of AMI image.', None),
+            ])
+
+  # Azure parser options
+  az_parser.add_argument('subscription_id', help='The Azure subscription ID.')
+  az_subparsers = az_parser.add_subparsers()
+  AddParser('az', az_subparsers, 'listinstances',
+            'List instances in Azure subscription.',
+            args=[
+                ('--resource_group_name', 'The resource group name from '
+                                          'which to list instances.', None)
+            ])
+  AddParser('az', az_subparsers, 'listdisks',
+            'List disks in Azure subscription.',
+            args=[
+              ('--resource_group_name', 'The resource group name from '
+                                        'which to list disks.', None)
+            ])
+  AddParser('az', az_subparsers, 'copydisk', 'Create an Azure disk copy.',
+            args=[
+                ('--instance_name', 'The instance name.', None),
+                ('--disk_name', 'The disk name of the disk to copy. If none '
+                                'specified, then --instance_name must be '
+                                'specified and the boot disk of the Azure '
+                                'instance will be copied.', None),
+                ('--disk_type', 'The SKU name for the disk to create. '
+                                'Can be Standard_LRS, Premium_LRS, '
+                                'StandardSSD_LRS, or UltraSSD_LRS.',
+                 None)
             ])
 
   # GCP parser options


### PR DESCRIPTION
Marking as draft until #174 is in.

Add CLI tool for Azure.

Usage:

```
libcloudforensics az <subscription_id> listinstances                                        
Instances found:
Name: foo, Boot disk: foo_OsDisk_1_xxx
Name: bar, Boot disk: bar_OsDisk_1_xxx
Name: test-east-vm-1, Boot disk: test-east-vm-1_xxx
...

libcloudforensics az <subscription_id> listinstances --resource_group_name=libcloudforensics
Instances found:
Name: foo, Boot disk: foo_OsDisk_1_xxx
Name: bar, Boot disk: bar_OsDisk_1_xxx

libcloudforensics az <subscription_id> listdisks                                            
Disks found:
Name: foo_OsDisk_1_xxx, Region: eastus
Name: bar_OsDisk_1_xxx, Region: westus

libcloudforensics az <subscription_id> copydisk --instance_name=foo
Starting disk copy...
Done! Disk evidence_foo_OsDisk_1_xxx_snapshot_xxx_copy successfully created.
```

Signed-off-by: Theo Giovanna <gtheo@google.com>