### PR TITLE
Add missing option to AWS CLI

### DIFF
--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -138,11 +138,12 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
   print('Starting analysis VM...')
   vm = forensics.StartAnalysisVm(vm_name=args.instance_name,
                                  default_availability_zone=args.zone,
-                                 boot_volume_size=int(args.disk_size),
+                                 boot_volume_size=int(args.boot_volume_size),
                                  cpu_cores=int(args.cpu_cores),
                                  ami=args.ami,
                                  ssh_key_name=args.ssh_key_name,
-                                 attach_volumes=attach_volumes)
+                                 attach_volumes=attach_volumes,
+                                 dst_profile=args.dst_profile)
 
   print('Analysis VM started.')
   print('Name: {0:s}, Started: {1:s}, Region: {2:s}'.format(vm[0].name,

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -134,7 +134,8 @@ def Main() -> None:
             args=[
                 ('instance_name', 'Name of EC2 instance to re-use or create.',
                  ''),
-                ('--boot_volume_size', 'Size of instance boot volume in GB.', '50'),
+                ('--boot_volume_size', 'Size of instance boot volume in GB.',
+                 '50'),
                 ('--cpu_cores', 'Instance CPU core count.', '4'),
                 ('--ami', 'AMI ID to use as base image. Will search '
                           'Ubuntu 18.04 LTS server x86_64 for chosen region '

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -131,14 +131,17 @@ def Main() -> None:
             args=[
                 ('instance_name', 'Name of EC2 instance to re-use or create.',
                  ''),
-                ('--disk_size', 'Size of disk in GB.', '50'),
+                ('--boot_volume_size', 'Size of volume in GB.', '50'),
                 ('--cpu_cores', 'Instance CPU core count.', '4'),
                 ('--ami', 'AMI ID to use as base image. Will search '
                           'Ubuntu 18.04 LTS server x86_64 for chosen region '
                           'by default.', ''),
                 ('--ssh_key_name', 'SSH key pair name.', None),
                 ('--attach_volumes', 'Comma seperated list of volume IDs '
-                                     'to attach. Maximum of 11.', None)
+                                     'to attach. Maximum of 11.', None),
+                ('--dst_profile', 'The name of the profile for the destination '
+                                  'account, as defined in the AWS credentials '
+                                  'file.', None)
             ])
   AddParser('aws', aws_subparsers, 'listimages', 'List AMI images.',
             args=[

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -134,7 +134,7 @@ def Main() -> None:
             args=[
                 ('instance_name', 'Name of EC2 instance to re-use or create.',
                  ''),
-                ('--boot_volume_size', 'Size of volume in GB.', '50'),
+                ('--boot_volume_size', 'Size of instance boot volume in GB.', '50'),
                 ('--cpu_cores', 'Instance CPU core count.', '4'),
                 ('--ami', 'AMI ID to use as base image. Will search '
                           'Ubuntu 18.04 LTS server x86_64 for chosen region '


### PR DESCRIPTION
While writing #199 I realised `dst_profile` was missing from the CLI for the `startvm` functionality. This parameter allows you to specify the AWS account in which to start the VM.

I've also switched `disk_size` to `boot_volume_size` until we solve #165.

Signed-off-by: Theo Giovanna <gtheo@google.com>