### PR TITLE
Implement cross-region and cross-account disk copy functionality

### DIFF
--- a/examples/az_cli.py
+++ b/examples/az_cli.py
@@ -30,7 +30,7 @@ def ListInstances(args: 'argparse.Namespace') -> None:
     args (argparse.Namespace): Arguments from ArgumentParser.
   """
 
-  az_account = account.AZAccount(args.subscription_id)
+  az_account = account.AZAccount(args.default_resource_group_name)
   instances = az_account.ListInstances(
       resource_group_name=args.resource_group_name)
 
@@ -47,7 +47,7 @@ def ListDisks(args: 'argparse.Namespace') -> None:
     args (argparse.Namespace): Arguments from ArgumentParser.
   """
 
-  az_account = account.AZAccount(args.subscription_id)
+  az_account = account.AZAccount(args.default_resource_group_name)
   disks = az_account.ListDisks(resource_group_name=args.resource_group_name)
 
   print('Disks found:')
@@ -62,8 +62,11 @@ def CreateDiskCopy(args: 'argparse.Namespace') -> None:
     args (argparse.Namespace): Arguments from ArgumentParser.
   """
   print('Starting disk copy...')
-  disk_copy = forensics.CreateDiskCopy(args.subscription_id,
-                                       args.instance_name,
-                                       args.disk_name,
-                                       args.disk_type)
+  disk_copy = forensics.CreateDiskCopy(args.default_resource_group_name,
+                                       instance_name=args.instance_name,
+                                       disk_name=args.disk_name,
+                                       disk_type=args.disk_type,
+                                       region=args.region,
+                                       src_profile=args.src_profile,
+                                       dst_profile=args.dst_profile)
   print('Done! Disk {0:s} successfully created.'.format(disk_copy.name))

--- a/examples/az_cli.py
+++ b/examples/az_cli.py
@@ -16,8 +16,12 @@
 
 from typing import TYPE_CHECKING
 
+from libcloudforensics import logging_utils
 from libcloudforensics.providers.azure.internal import account
 from libcloudforensics.providers.azure import forensics
+
+logging_utils.SetUpLogger(__name__)
+logger = logging_utils.GetLogger(__name__)
 
 if TYPE_CHECKING:
   import argparse
@@ -34,10 +38,10 @@ def ListInstances(args: 'argparse.Namespace') -> None:
   instances = az_account.ListInstances(
       resource_group_name=args.resource_group_name)
 
-  print('Instances found:')
+  logger.info('Instances found:')
   for instance in instances.values():
     boot_disk = instance.GetBootDisk().name
-    print('Name: {0:s}, Boot disk: {1:s}'.format(instance, boot_disk))
+    logger.info('Name: {0:s}, Boot disk: {1:s}'.format(instance, boot_disk))
 
 
 def ListDisks(args: 'argparse.Namespace') -> None:
@@ -50,9 +54,9 @@ def ListDisks(args: 'argparse.Namespace') -> None:
   az_account = account.AZAccount(args.default_resource_group_name)
   disks = az_account.ListDisks(resource_group_name=args.resource_group_name)
 
-  print('Disks found:')
+  logger.info('Disks found:')
   for disk in disks:
-    print('Name: {0:s}, Region: {1:s}'.format(disk, disks[disk].region))
+    logger.info('Name: {0:s}, Region: {1:s}'.format(disk, disks[disk].region))
 
 
 def CreateDiskCopy(args: 'argparse.Namespace') -> None:
@@ -61,7 +65,7 @@ def CreateDiskCopy(args: 'argparse.Namespace') -> None:
   Args:
     args (argparse.Namespace): Arguments from ArgumentParser.
   """
-  print('Starting disk copy...')
+  logger.info('Starting disk copy...')
   disk_copy = forensics.CreateDiskCopy(args.default_resource_group_name,
                                        instance_name=args.instance_name,
                                        disk_name=args.disk_name,
@@ -69,4 +73,4 @@ def CreateDiskCopy(args: 'argparse.Namespace') -> None:
                                        region=args.region,
                                        src_profile=args.src_profile,
                                        dst_profile=args.dst_profile)
-  print('Done! Disk {0:s} successfully created.'.format(disk_copy.name))
+  logger.info('Done! Disk {0:s} successfully created.'.format(disk_copy.name))

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -159,7 +159,9 @@ def Main() -> None:
             ])
 
   # Azure parser options
-  az_parser.add_argument('subscription_id', help='The Azure subscription ID.')
+  az_parser.add_argument('default_resource_group_name',
+                         help='The default resource group name in which to '
+                              'create resources')
   az_subparsers = az_parser.add_subparsers()
   AddParser('az', az_subparsers, 'listinstances',
             'List instances in Azure subscription.',
@@ -182,8 +184,19 @@ def Main() -> None:
                                 'instance will be copied.', None),
                 ('--disk_type', 'The SKU name for the disk to create. '
                                 'Can be Standard_LRS, Premium_LRS, '
-                                'StandardSSD_LRS, or UltraSSD_LRS.',
-                 None)
+                                'StandardSSD_LRS, or UltraSSD_LRS.', None),
+                ('--region', 'The region in which to create the disk copy. If '
+                             'not provided, the disk copy will be created in '
+                             'the "eastus" region.', None),
+                ('--src_profile', 'The Azure profile information to use as '
+                                  'source account for the disk copy. Default '
+                                  'will look into environment variables to '
+                                  'authenticate the requests.', None),
+                ('--dst_profile', 'The Azure profile information to use as '
+                                  'destination account for the disk copy. If '
+                                  'not provided, the default behavior is to '
+                                  'use the same destination profile as the '
+                                  'source profile.', None)
             ])
 
   # GCP parser options

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -184,10 +184,11 @@ def Main() -> None:
                                 'instance will be copied.', None),
                 ('--disk_type', 'The SKU name for the disk to create. '
                                 'Can be Standard_LRS, Premium_LRS, '
-                                'StandardSSD_LRS, or UltraSSD_LRS.', None),
+                                'StandardSSD_LRS, or UltraSSD_LRS. Default is '
+                                'Standard_LRS', 'Standard_LRS'),
                 ('--region', 'The region in which to create the disk copy. If '
                              'not provided, the disk copy will be created in '
-                             'the "eastus" region.', None),
+                             'the "eastus" region.', 'eastus'),
                 ('--src_profile', 'The Azure profile information to use as '
                                   'source account for the disk copy. Default '
                                   'will look into environment variables to '

--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -31,7 +31,7 @@ def CreateDiskCopy(
     instance_name: Optional[str] = None,
     disk_name: Optional[str] = None,
     disk_type: str = 'Standard_LRS',
-    region: Optional[str] = None,
+    region: str = 'eastus',
     src_profile: Optional[str] = None,
     dst_profile: Optional[str] = None) -> 'compute.AZDisk':
   """Creates a copy of an Azure Compute Disk.
@@ -48,8 +48,8 @@ def CreateDiskCopy(
     disk_type (str): Optional. The sku name for the disk to create. Can be
         Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
         default value is Standard_LRS.
-    region (str): Optional. The region in which to create the disk copy. If not
-        provided, the disk will be created in the default_region (eastus).
+    region (str): Optional. The region in which to create the disk copy.
+        Default is eastus.
     src_profile (str): Optional. The name of the source profile to use for the
         disk copy, i.e. the account information of the Azure account that holds
         the disk. For more information on profiles, see GetCredentials()

--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -100,6 +100,7 @@ def CreateDiskCopy(
     # which we import the previously created snapshot (cross-region/account
     # sharing).
     if diff_account or diff_region:
+      logger.info('Copy requested in a different destination account/region.')
       # Create a link to download the snapshot
       snapshot_uri = snapshot.GrantAccessAndGetURI()
       # Make a snapshot copy in the destination account from the link

--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -16,22 +16,25 @@
 
 from typing import TYPE_CHECKING, Optional
 
-from libcloudforensics.providers.azure.internal import account
-from libcloudforensics.providers.azure.internal import common
+from libcloudforensics.providers.azure.internal import account, common
 
 if TYPE_CHECKING:
   from libcloudforensics.providers.azure.internal import compute
 
 
 def CreateDiskCopy(
-    subscription_id: str,
+    resource_group_name: str,
     instance_name: Optional[str] = None,
     disk_name: Optional[str] = None,
-    disk_type: str = 'Standard_LRS') -> 'compute.AZDisk':
+    disk_type: str = 'Standard_LRS',
+    region: Optional[str] = None,
+    src_profile: Optional[str] = None,
+    dst_profile: Optional[str] = None) -> 'compute.AZDisk':
   """Creates a copy of an Azure Compute Disk.
 
   Args:
-    subscription_id (str): The Azure subscription ID to use.
+    resource_group_name (str): The resource group in which to create the disk
+        copy.
     instance_name (str): Optional. Instance name of the instance using the
         disk to be copied. If specified, the boot disk of the instance will be
         copied. If disk_name is also specified, then the disk pointed to by
@@ -41,6 +44,19 @@ def CreateDiskCopy(
     disk_type (str): Optional. The sku name for the disk to create. Can be
           Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
           default value is Standard_LRS.
+    region (str): Optional. The region in which to create the disk copy. If not
+          provided, the disk will be created in the default_region (eastus).
+    src_profile (str): Optional. The name of the source profile to use for the
+        disk copy, i.e. the account information of the Azure account that holds
+        the disk. For more information on profiles, see GetCredentials()
+        in libcloudforensics.providers.azure.internal.common.py. If not
+        provided, credentials will be gathered from environment variables.
+    dst_profile (str): Optional. The name of the destination profile to use for
+        the disk copy. The disk will be copied into the account linked to
+        this profile. If not provided, the default behavior is that the
+        destination profile is the same as the source profile.
+        For more information on profiles, see GetCredentials() in
+        libcloudforensics.providers.azure.internal.common.py
 
   Returns:
     AZDisk: An Azure Compute Disk object.
@@ -54,18 +70,47 @@ def CreateDiskCopy(
     raise ValueError(
         'You must specify at least one of [instance_name, disk_name].')
 
-  az_account = account.AZAccount(subscription_id)
+  src_account = account.AZAccount(
+      resource_group_name, default_region=region, profile_name=src_profile)
+  dst_account = account.AZAccount(resource_group_name,
+                                  default_region=region,
+                                  profile_name=(dst_profile or src_profile))
 
   try:
     if disk_name:
-      disk_to_copy = az_account.GetDisk(disk_name)
+      disk_to_copy = src_account.GetDisk(disk_name)
     elif instance_name:
-      instance = az_account.GetInstance(instance_name)
+      instance = src_account.GetInstance(instance_name)
       disk_to_copy = instance.GetBootDisk()
     common.LOGGER.info('Disk copy of {0:s} started...'.format(
         disk_to_copy.name))
     snapshot = disk_to_copy.Snapshot()
-    new_disk = az_account.CreateDiskFromSnapshot(
+
+    # pylint: disable=line-too-long
+    diff_account = dst_account.subscription_id not in src_account.ListSubscriptionIDs()
+    # pylint: enable=line-too-long
+    diff_region = dst_account.default_region != snapshot.region
+
+    # If the destination account is different from the source account or if the
+    # destination region is not the same as the region in which the source
+    # disk is, then we need to create the disk from a storage account in
+    # which we import the previously created snapshot (cross-region/account
+    # sharing).
+    if diff_account or diff_region:
+      # Create a link to download the snapshot
+      snapshot_uri = snapshot.GrantAccessAndGetURI()
+      # Make a snapshot copy in the destination account from the link
+      new_disk = dst_account.CreateDiskFromSnapshotURI(
+          snapshot,
+          snapshot_uri,
+          disk_name_prefix=common.DEFAULT_DISK_COPY_PREFIX,
+          disk_type=disk_type)
+      # Revoke download link and delete the initial copy
+      snapshot.RevokeAccessURI()
+      snapshot.Delete()
+      return new_disk
+
+    new_disk = dst_account.CreateDiskFromSnapshot(
         snapshot,
         disk_name_prefix=common.DEFAULT_DISK_COPY_PREFIX,
         disk_type=disk_type)

--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -42,10 +42,10 @@ def CreateDiskCopy(
     disk_name (str): Optional. Name of the disk to copy. If not set,
         then instance_name needs to be set and the boot disk will be copied.
     disk_type (str): Optional. The sku name for the disk to create. Can be
-          Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
-          default value is Standard_LRS.
+        Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
+        default value is Standard_LRS.
     region (str): Optional. The region in which to create the disk copy. If not
-          provided, the disk will be created in the default_region (eastus).
+        provided, the disk will be created in the default_region (eastus).
     src_profile (str): Optional. The name of the source profile to use for the
         disk copy, i.e. the account information of the Azure account that holds
         the disk. For more information on profiles, see GetCredentials()
@@ -86,13 +86,12 @@ def CreateDiskCopy(
         disk_to_copy.name))
     snapshot = disk_to_copy.Snapshot()
 
-    # pylint: disable=line-too-long
-    diff_account = dst_account.subscription_id not in src_account.ListSubscriptionIDs()
-    # pylint: enable=line-too-long
+    subscription_ids = src_account.ListSubscriptionIDs()
+    diff_account = dst_account.subscription_id not in subscription_ids
     diff_region = dst_account.default_region != snapshot.region
 
     # If the destination account is different from the source account or if the
-    # destination region is not the same as the region in which the source
+    # destination region is different from the region in which the source
     # disk is, then we need to create the disk from a storage account in
     # which we import the previously created snapshot (cross-region/account
     # sharing).
@@ -107,13 +106,11 @@ def CreateDiskCopy(
           disk_type=disk_type)
       # Revoke download link and delete the initial copy
       snapshot.RevokeAccessURI()
-      snapshot.Delete()
-      return new_disk
-
-    new_disk = dst_account.CreateDiskFromSnapshot(
-        snapshot,
-        disk_name_prefix=common.DEFAULT_DISK_COPY_PREFIX,
-        disk_type=disk_type)
+    else:
+      new_disk = dst_account.CreateDiskFromSnapshot(
+          snapshot,
+          disk_name_prefix=common.DEFAULT_DISK_COPY_PREFIX,
+          disk_type=disk_type)
     snapshot.Delete()
     common.LOGGER.info(
         'Disk {0:s} successfully copied to {1:s}'.format(

--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -16,10 +16,14 @@
 
 from typing import TYPE_CHECKING, Optional
 
+from libcloudforensics import logging_utils
 from libcloudforensics.providers.azure.internal import account, common
 
 if TYPE_CHECKING:
   from libcloudforensics.providers.azure.internal import compute
+
+logging_utils.SetUpLogger(__name__)
+logger = logging_utils.GetLogger(__name__)
 
 
 def CreateDiskCopy(
@@ -82,7 +86,7 @@ def CreateDiskCopy(
     elif instance_name:
       instance = src_account.GetInstance(instance_name)
       disk_to_copy = instance.GetBootDisk()
-    common.LOGGER.info('Disk copy of {0:s} started...'.format(
+    logger.info('Disk copy of {0:s} started...'.format(
         disk_to_copy.name))
     snapshot = disk_to_copy.Snapshot()
 
@@ -112,9 +116,8 @@ def CreateDiskCopy(
           disk_name_prefix=common.DEFAULT_DISK_COPY_PREFIX,
           disk_type=disk_type)
     snapshot.Delete()
-    common.LOGGER.info(
-        'Disk {0:s} successfully copied to {1:s}'.format(
-            disk_to_copy.name, new_disk.name))
+    logger.info('Disk {0:s} successfully copied to {1:s}'.format(
+        disk_to_copy.name, new_disk.name))
   except RuntimeError as exception:
     error_msg = 'Cannot copy disk "{0:s}": {1!s}'.format(
         str(disk_name), str(exception))

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -31,6 +31,10 @@ from msrestazure.azure_exceptions import CloudError
 # pylint: enable=import-error
 
 from libcloudforensics.providers.azure.internal import compute, common
+from libcloudforensics import logging_utils
+
+logging_utils.SetUpLogger(__name__)
+logger = logging_utils.GetLogger(__name__)
 
 
 class AZAccount:
@@ -316,6 +320,7 @@ class AZAccount:
       container_client.create_container()
     except ResourceExistsError:
       # The container already exists, so we can re-use it
+      logger.warning('Reusing existing container: {0:s}'.format(container_name))
       pass
 
     # Download the snapshot from the URI to the storage

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -332,8 +332,13 @@ class AZAccount:
                 'Depending on the size of the snapshot, this process is going '
                 'to take a while.'.format(snapshot_uri))
     copied_blob.start_copy_from_url(snapshot_uri)
-    while copied_blob.get_blob_properties().copy.status != 'success':
+    copy_status = copied_blob.get_blob_properties().copy.status
+    while copy_status != 'success':
       sleep(5)  # Wait for the vhd to be imported in the Azure storage container
+      copy_status = copied_blob.get_blob_properties().copy.status
+      if copy_status in ('aborted', 'failed'):
+        raise RuntimeError('Could not import the snapshot from URI '
+                           '{0:s}'.format(snapshot_uri))
       logger.debug('Importing snapshot from URI {0:s}'.format(snapshot_uri))
     logger.info('Snapshot successfully imported from URI {0:s}'.format(
         snapshot_uri))

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -13,15 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Represents an Azure account."""
-
+import hashlib
 from time import sleep
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple, List
 
 # Pylint complains about the import but the library imports just fine,
 # so we can ignore the warning.
 # pylint: disable=import-error
+from azure.core.exceptions import ResourceExistsError
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.compute.v2016_04_30_preview.models import DiskCreateOption
+from azure.mgmt.resource import SubscriptionClient
+from azure.mgmt.storage import StorageManagementClient
+from azure.storage.blob import BlobServiceClient
+from azure.mgmt.resource import ResourceManagementClient
 from msrestazure.azure_exceptions import CloudError
 # pylint: enable=import-error
 
@@ -37,16 +42,44 @@ class AZAccount:
     compute_client (ComputeManagementClient): An Azure compute client object.
   """
 
-  def __init__(self, subscription_id: str) -> None:
+  def __init__(self,
+               default_resource_group_name: str,
+               default_region: Optional[str] = None,
+               profile_name: Optional[str] = None) -> None:
     """Initialize the AZAccount class.
 
     Args:
-      subscription_id (str): The Azure subscription ID to use.
+      default_resource_group_name (str): The default resource group in which to
+          create new resources in. If the resource group does not exists,
+          it will be automatically created.
+      default_region (str): Optional. The default region to create new
+          resources in. If None, it will default to eastus.
+      profile_name (str): Optional. The name of the profile to use for Azure
+          operations. For more information on profiles, see GetCredentials()
+          in libcloudforensics.providers.azure.internal.common.py. Default
+          does not use profiles and will authenticate to Azure using
+          environment variables.
     """
-    self.subscription_id = subscription_id
-    self.credentials = common.GetCredentials()
+    self.subscription_id, self.credentials = common.GetCredentials(profile_name)
+    self.default_region = default_region or 'eastus'
     self.compute_client = ComputeManagementClient(
         self.credentials, self.subscription_id)
+    self.storage_client = StorageManagementClient(
+        self.credentials, self.subscription_id)
+    self.resource_client = ResourceManagementClient(
+        self.credentials, self.subscription_id)
+    self.default_resource_group_name = self._GetOrCreateResourceGroup(
+        default_resource_group_name)
+
+  def ListSubscriptionIDs(self) -> List[str]:
+    """List subscription ids from an Azure account.
+
+    Returns:
+      List[str]: A list of all subscription IDs from the Azure account.
+    """
+    subscription_client = SubscriptionClient(self.credentials)
+    subscription_ids = subscription_client.subscriptions.list()
+    return [sub.subscription_id for sub in subscription_ids]
 
   def ListInstances(self,
                     resource_group_name: Optional[str] = None
@@ -168,6 +201,7 @@ class AZAccount:
   def CreateDiskFromSnapshot(
       self,
       snapshot: compute.AZSnapshot,
+      region: Optional[str] = None,
       disk_name: Optional[str] = None,
       disk_name_prefix: Optional[str] = None,
       disk_type: str = 'Standard_LRS') -> compute.AZDisk:
@@ -175,6 +209,9 @@ class AZAccount:
 
     Args:
       snapshot (AZSnapshot): Snapshot to use.
+      region (str): Optional. The region in which to create the disk. If not
+          provided, the disk will be created in the default_region associated to
+          the AZAccount object.
       disk_name (str): Optional. String to use as new disk name.
       disk_name_prefix (str): Optional. String to prefix the disk name with.
       disk_type (str): Optional. The sku name for the disk to create. Can be
@@ -191,8 +228,12 @@ class AZAccount:
     if not disk_name:
       disk_name = common.GenerateDiskName(snapshot,
                                           disk_name_prefix=disk_name_prefix)
+
+    if not region:
+      region = self.default_region
+
     creation_data = {
-        'location': snapshot.region,
+        'location': region,
         'creation_data': {
             'sourceResourceId': snapshot.resource_id,
             'create_option': DiskCreateOption.copy
@@ -201,7 +242,7 @@ class AZAccount:
 
     try:
       request = self.compute_client.disks.create_or_update(
-          snapshot.resource_group_name,
+          self.default_resource_group_name,
           disk_name,
           creation_data,
           sku=disk_type)
@@ -217,3 +258,187 @@ class AZAccount:
                           disk.name,
                           disk.location,
                           disk.zones)
+
+  def CreateDiskFromSnapshotURI(
+      self,
+      snapshot: compute.AZSnapshot,
+      snapshot_uri: str,
+      region: Optional[str] = None,
+      disk_name: Optional[str] = None,
+      disk_name_prefix: Optional[str] = None,
+      disk_type: str = 'Standard_LRS') -> compute.AZDisk:
+    """Create a new disk based on a SAS snapshot URI.
+
+    This is useful if e.g. one wants to make a copy of a disk in a separate
+    Azure account. This method will create a temporary Azure Storage account
+    within the destination account, import the snapshot from a downloadable
+    link (the source account needs to share the snapshot through a SAS link)
+    and then create a disk from the VHD file saved in storage. The Azure
+    storage account is then deleted.
+
+    Args:
+      snapshot (AZSnapshot): Source snapshot to use.
+      snapshot_uri (str): The URI of the snapshot to copy.
+      region (str): Optional. The region in which to create the disk. If not
+          provided, the disk will be created in the default_region associated to
+          the AZAccount object.
+      disk_name (str): Optional. String to use as new disk name.
+      disk_name_prefix (str): Optional. String to prefix the disk name with.
+      disk_type (str): Optional. The sku name for the disk to create. Can be
+          Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS.
+          Default is Standard_LRS.
+
+    Returns:
+      AZDisk: Azure Compute Disk.
+
+    Raises:
+      RuntimeError: If the disk could not be created.
+    """
+
+    if not region:
+      region = self.default_region
+
+    # Create a temporary Azure account storage to import the snapshot
+    storage_account_name = hashlib.sha1(
+        snapshot.resource_id.encode('utf-8')).hexdigest()[:23]
+    storage_account_url = 'https://{0:s}.blob.core.windows.net'.format(
+        storage_account_name)
+    storage_account_id, storage_account_access_key = self._CreateStorageAccount(
+        storage_account_name, region=region)
+    blob_service_client = BlobServiceClient(
+        account_url=storage_account_url, credential=storage_account_access_key)
+
+    # Create a container within the Storage to receive the imported snapshot
+    container_name = storage_account_name + '-container'
+    snapshot_vhd_name = snapshot.name + '.vhd'
+    container_client = blob_service_client.get_container_client(container_name)
+    try:
+      container_client.create_container()
+    except ResourceExistsError:
+      # The container already exists, so we can re-use it
+      pass
+
+    # Download the snapshot from the URI to the storage
+    copied_blob = blob_service_client.get_blob_client(
+        container_name, snapshot_vhd_name)
+    copied_blob.start_copy_from_url(snapshot_uri)
+    while copied_blob.get_blob_properties().copy.status != 'success':
+      sleep(5)  # Wait for the vhd to be imported in the Azure storage container
+
+    if not disk_name:
+      disk_name = common.GenerateDiskName(snapshot,
+                                          disk_name_prefix=disk_name_prefix)
+
+    # Create a new disk from the imported snapshot
+    creation_data = {
+        'location': region,
+        'creation_data': {
+            'source_uri': copied_blob.url,
+            'storage_account_id': storage_account_id,
+            'create_option': DiskCreateOption.import_enum
+        }
+    }
+
+    try:
+      request = self.compute_client.disks.create_or_update(
+          self.default_resource_group_name,
+          disk_name,
+          creation_data,
+          sku=disk_type)
+      while not request.done():
+        sleep(5)  # Wait 5 seconds before checking disk status again
+      disk = request.result()
+    except CloudError as exception:
+      raise RuntimeError('Could not create disk from URI {0:s}: {1:s}'
+                         .format(snapshot_uri, str(exception)))
+
+    # Cleanup the temporary account storage
+    self._DeleteStorageAccount(storage_account_name)
+
+    return compute.AZDisk(self,
+                          disk.id,
+                          disk.name,
+                          disk.location,
+                          disk.zones)
+
+  def _CreateStorageAccount(self,
+                            storage_account_name: str,
+                            region: Optional[str] = None) -> Tuple[str, str]:
+    """Create a storage account and returns its ID and access key.
+
+    Args:
+      storage_account_name (str): The name for the storage account.
+      region (str): Optional. The region in which to create the storage
+          account. If not provided, it will be created in the default_region
+          associated to the AZAccount object.
+
+    Returns:
+      Tuple[str, str]: The storage account ID and its access key.
+
+    Raises:
+      ValueError: If the storage account name is invalid.
+    """
+
+    if not common.REGEX_ACCOUNT_STORAGE_NAME.match(storage_account_name):
+      raise ValueError(
+          'Storage account name {0:s} does not comply with {1:s}'.format(
+              storage_account_name, common.REGEX_ACCOUNT_STORAGE_NAME.pattern))
+
+    if not region:
+      region = self.default_region
+
+    creation_data = {
+        'location': region,
+        'sku': {
+            'name': 'Standard_RAGRS'
+        },
+        'kind': 'Storage'
+    }
+
+    request = self.storage_client.storage_accounts.create(
+        self.default_resource_group_name,
+        storage_account_name,
+        creation_data
+    )
+    storage_account = request.result()
+    storage_account_keys = self.storage_client.storage_accounts.list_keys(
+        self.default_resource_group_name, storage_account_name)
+    storage_account_keys = {v.key_name: v.value
+                            for v in storage_account_keys.keys}
+    storage_account_id = storage_account.id  # type: str
+    storage_account_key = storage_account_keys['key1']  # type: str
+    return storage_account_id, storage_account_key
+
+  def _DeleteStorageAccount(self, storage_account_name: str) -> None:
+    """Delete an account storage.
+
+    Raises:
+      RuntimeError: if the storage account could not be deleted.
+    """
+    try:
+      self.storage_client.storage_accounts.delete(
+          self.default_resource_group_name, storage_account_name)
+    except CloudError as exception:
+      raise RuntimeError('Could not delete account storage {0:s}: {1:s}'
+                         .format(storage_account_name, str(exception)))
+
+  def _GetOrCreateResourceGroup(self, resource_group_name: str) -> str:
+    """Check if a resource group exists, and create it otherwise."
+
+    Args:
+      resource_group_name (str); The name of the resource group to check
+          existence for. If it does not exist, create it.
+
+    Returns:
+      str: The resource group name.
+    """
+    try:
+      self.resource_client.resource_groups.get(resource_group_name)
+    except CloudError:
+      # Group doesn't exist, creating it
+      creation_data = {
+          'location': self.default_region
+      }
+      self.resource_client.resource_groups.create_or_update(
+          resource_group_name, creation_data)
+    return resource_group_name

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -46,7 +46,7 @@ class AZAccount:
 
   def __init__(self,
                default_resource_group_name: str,
-               default_region: Optional[str] = None,
+               default_region: str = 'eastus',
                profile_name: Optional[str] = None) -> None:
     """Initialize the AZAccount class.
 
@@ -55,7 +55,7 @@ class AZAccount:
           create new resources in. If the resource group does not exists,
           it will be automatically created.
       default_region (str): Optional. The default region to create new
-          resources in. If None, it will default to eastus.
+          resources in. Default is eastus.
       profile_name (str): Optional. The name of the profile to use for Azure
           operations. For more information on profiles, see GetCredentials()
           in libcloudforensics.providers.azure.internal.common.py. Default
@@ -63,7 +63,7 @@ class AZAccount:
           environment variables.
     """
     self.subscription_id, self.credentials = common.GetCredentials(profile_name)
-    self.default_region = default_region or 'eastus'
+    self.default_region = default_region
     self.compute_client = azure_compute.ComputeManagementClient(
         self.credentials, self.subscription_id)
     self.storage_client = storage.StorageManagementClient(
@@ -402,6 +402,7 @@ class AZAccount:
     if not region:
       region = self.default_region
 
+    # https://docs.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
     creation_data = {
         'location': region,
         'sku': {

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -321,7 +321,6 @@ class AZAccount:
     except ResourceExistsError:
       # The container already exists, so we can re-use it
       logger.warning('Reusing existing container: {0:s}'.format(container_name))
-      pass
 
     # Download the snapshot from the URI to the storage
     copied_blob = blob_service_client.get_blob_client(

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -160,7 +160,7 @@ def ExecuteRequest(
     request = getattr(client, func)
     response = request(**kwargs)
     responses.append(response)
-    next_link = response.getattr('next_link', None)
+    next_link = response.next_link if hasattr(response, 'next_link') else None
     if not next_link:
       return responses
 

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -120,7 +120,7 @@ def GetCredentials(profile_name: Optional[str] = None
               profile_name, path))
     required_entries = ['subscriptionId', 'clientId', 'clientSecret',
                         'tenantId']
-    if not all(entry in account_info for entry in required_entries):
+    if not all(account_info.get(entry) for entry in required_entries):
       raise ValueError(
           'Please make sure that your JSON file has the required entries. The '
           'file should contain at least the following: {0:s}'.format(
@@ -160,7 +160,7 @@ def ExecuteRequest(
     request = getattr(client, func)
     response = request(**kwargs)
     responses.append(response)
-    next_link = response.next_link if hasattr(response, 'next_link') else None
+    next_link = response.getattr('next_link', None)
     if not next_link:
       return responses
 

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -16,7 +16,6 @@
 
 import binascii
 import json
-import logging
 import os
 import re
 
@@ -38,8 +37,6 @@ REGEX_SNAPSHOT_NAME = re.compile('^(?=.{1,80}$)[a-zA-Z0-9]([\\w,-]*[\\w])?$')
 REGEX_ACCOUNT_STORAGE_NAME = re.compile('^[a-z0-9]{1,24}$')
 
 DEFAULT_DISK_COPY_PREFIX = 'evidence'
-
-LOGGER = logging.getLogger()
 
 
 def GetCredentials(profile_name: Optional[str] = None

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -15,11 +15,12 @@
 """Common utilities."""
 
 import binascii
+import json
 import logging
 import os
 import re
 
-from typing import Any, List, Dict, Optional, TYPE_CHECKING
+from typing import Any, List, Dict, Optional, TYPE_CHECKING, Tuple
 # Pylint complains about the import but the library imports just fine,
 # so we can ignore the warning.
 from azure.common.credentials import ServicePrincipalCredentials  # pylint: disable=import-error
@@ -34,21 +35,103 @@ if TYPE_CHECKING:
 # pylint: enable=line-too-long
 REGEX_DISK_NAME = re.compile('^[\\w]{1,80}$')
 REGEX_SNAPSHOT_NAME = re.compile('^(?=.{1,80}$)[a-zA-Z0-9]([\\w,-]*[\\w])?$')
+REGEX_ACCOUNT_STORAGE_NAME = re.compile('^[a-z0-9]{1,24}$')
 
 DEFAULT_DISK_COPY_PREFIX = 'evidence'
 
 LOGGER = logging.getLogger()
 
 
-def GetCredentials() -> ServicePrincipalCredentials:
+def GetCredentials(profile_name: Optional[str] = None
+                   ) -> Tuple[str, ServicePrincipalCredentials]:
+  # pylint: disable=line-too-long
   """Get Azure credentials.
 
+  Args:
+    profile_name (str): A name for the Azure account information to retrieve.
+        If not provided, the default behavior is to look for Azure credential
+        information in environment variables as explained in https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate
+        If provided, then the library will look into
+        ~/.azure/credentials.json for the account information linked to
+        profile_name. The .json file should have the following format:
+
+        {
+          'profile_name': {
+              'subscriptionId': xxx,
+              'tenantId': xxx,
+              'clientId': xxx,
+              'clientSecret': xxx
+          },
+          'other_profile_name': {
+              'subscriptionId': yyy,
+              'tenantId': yyy,
+              'clientId': yyy,
+              'clientSecret': yyy
+          },
+          ...
+        }
+
+        Note that you can specify several profiles that use the same tenantId,
+        clientId and clientSecret but a different subscriptionId.
+        If you set the environment variable AZURE_CREDENTIALS_PATH to an
+        absolute path to the credentials file, then the library will look
+        there instead of in ~/.azure/credentials.json.
+
   Returns:
-    ServicePrincipalCredentials: Azure credentials.
+    Tuple[str, ServicePrincipalCredentials]: Subscription ID and
+        corresponding Azure credentials.
+
+  Raises:
+    RuntimeError: If the credential file is not found.
+    ValueError: If the requested profile name is not found in the credential
+        file or if there are missing entries in the profile name.
   """
-  return ServicePrincipalCredentials(tenant=os.environ["AZURE_TENANT_ID"],
-                                     client_id=os.environ["AZURE_CLIENT_ID"],
-                                     secret=os.environ["AZURE_CLIENT_SECRET"])
+  # pylint: enable=line-too-long
+  if not profile_name:
+    subscription_id = os.getenv('AZURE_SUBSCRIPTION_ID')
+    client_id = os.getenv("AZURE_CLIENT_ID")
+    secret = os.getenv("AZURE_CLIENT_SECRET")
+    tenant = os.getenv("AZURE_TENANT_ID")
+    if not (subscription_id and client_id and secret and tenant):
+      raise RuntimeError('Please make sure you defined the following '
+                         'environment variables: [AZURE_SUBSCRIPTION_ID,'
+                         'AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,'
+                         'AZURE_TENANT_ID].')
+    return subscription_id, ServicePrincipalCredentials(client_id,
+                                                        secret,
+                                                        tenant=tenant)
+
+  path = os.getenv('AZURE_CREDENTIALS_PATH')
+  if not path:
+    path = os.path.expanduser('~/.azure/credentials.json')
+
+  if not os.path.exists(path):
+    raise RuntimeError('Credential files not found. Please place it in '
+                       '"~/.azure/credentials.json" or specify an absolute '
+                       'path to it in the AZURE_CREDENTIALS_PATH environment '
+                       'variable.')
+
+  with open(path) as profiles:
+    try:
+      account_info = json.load(profiles).get(profile_name)
+    except ValueError as exception:
+      raise ValueError('Could not decode JSON file. Please verify the file '
+                       'format: {0:s}'.format(str(exception)))
+    if not account_info:
+      raise ValueError(
+          'Profile name {0:s} not found in credentials file {1:s}'.format(
+              profile_name, path))
+    required_entries = ['subscriptionId', 'clientId', 'clientSecret',
+                        'tenantId']
+    if not all(entry in account_info for entry in required_entries):
+      raise ValueError(
+          'Please make sure that your JSON file has the required entries. The '
+          'file should contain at least the following: {0:s}'.format(
+              ', '.join(required_entries)))
+    return account_info['subscriptionId'], ServicePrincipalCredentials(
+        account_info['clientId'],
+        account_info['clientSecret'],
+        tenant=account_info['tenantId'])
 
 
 def ExecuteRequest(
@@ -80,7 +163,7 @@ def ExecuteRequest(
     request = getattr(client, func)
     response = request(**kwargs)
     responses.append(response)
-    next_link = response.next_link
+    next_link = response.next_link if hasattr(response, 'next_link') else None
     if not next_link:
       return responses
 

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -20,8 +20,8 @@ from typing import Optional, List, Dict, TYPE_CHECKING
 # Pylint complains about the import but the library imports just fine,
 # so we can ignore the warning.
 # pylint: disable=import-error
-from azure.mgmt.compute.v2016_04_30_preview.models import DiskCreateOption
-from msrestazure.azure_exceptions import CloudError
+from azure.mgmt.compute.v2020_05_01 import models
+from msrestazure import azure_exceptions
 # pylint: enable=import-error
 
 from libcloudforensics.providers.azure.internal import common
@@ -209,7 +209,7 @@ class AZDisk(AZComputeResource):
         'location': self.region,
         'creation_data': {
             'sourceResourceId': self.resource_id,
-            'create_option': DiskCreateOption.copy
+            'create_option': models.DiskCreateOption.copy
         }
     }
 
@@ -224,7 +224,7 @@ class AZDisk(AZComputeResource):
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking snapshot status again
       snapshot = request.result()
-    except CloudError as exception:
+    except azure_exceptions.CloudError as exception:
       raise RuntimeError('Could not create snapshot for disk {0:s}: {1:s}'
                          .format(self.resource_id, str(exception)))
 
@@ -272,7 +272,7 @@ class AZSnapshot(AZComputeResource):
           self.resource_group_name, self.name)
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking snapshot status again
-    except CloudError as exception:
+    except azure_exceptions.CloudError as exception:
       raise RuntimeError('Could not delete snapshot {0:s}: {1:s}'
                          .format(self.resource_id, str(exception)))
 
@@ -282,9 +282,9 @@ class AZSnapshot(AZComputeResource):
     Returns:
       str: The access URI for the snapshot.
     """
-    snapshot = self.az_account.compute_client.snapshots.grant_access(
+    access_request = self.az_account.compute_client.snapshots.grant_access(
         self.resource_group_name, self.name, 'Read', 3600)
-    snapshot_uri = snapshot.result().access_sas  # type: str
+    snapshot_uri = access_request.result().access_sas  # type: str
     return snapshot_uri
 
   def RevokeAccessURI(self) -> None:

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -275,3 +275,20 @@ class AZSnapshot(AZComputeResource):
     except CloudError as exception:
       raise RuntimeError('Could not delete snapshot {0:s}: {1:s}'
                          .format(self.resource_id, str(exception)))
+
+  def GrantAccessAndGetURI(self) -> str:
+    """Grant access to a snapshot and return its access URI.
+
+    Returns:
+      str: The access URI for the snapshot.
+    """
+    snapshot = self.az_account.compute_client.snapshots.grant_access(
+        self.resource_group_name, self.name, 'Read', 3600)
+    snapshot_uri = snapshot.result().access_sas  # type: str
+    return snapshot_uri
+
+  def RevokeAccessURI(self) -> None:
+    """Revoke access to a snapshot."""
+    request = self.az_account.compute_client.snapshots.revoke_access(
+        self.resource_group_name, self.name)
+    request.wait()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ azure-core
 azure-identity
 azure-mgmt-compute==13.0.0
 azure-mgmt-resource
-azure-mgmt-storage
+azure-mgmt-storage==11.1.0
 azure-storage-blob
 msrest
 msrestazure

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,7 @@ azure-core
 azure-identity
 azure-mgmt-compute==13.0.0
 azure-mgmt-resource
+azure-mgmt-storage
+azure-storage-blob
 msrest
 msrestazure

--- a/tests/providers/azure/azure_e2e.py
+++ b/tests/providers/azure/azure_e2e.py
@@ -17,7 +17,7 @@
 import typing
 import unittest
 
-from msrestazure.azure_exceptions import CloudError  # pylint: disable=import-error
+from msrestazure import azure_exceptions  # pylint: disable=import-error
 from libcloudforensics import logging_utils
 from libcloudforensics.providers.azure.internal import account
 from libcloudforensics.providers.azure import forensics
@@ -147,7 +147,7 @@ class EndToEndTest(unittest.TestCase):
       logger.info('Deleting disk: {0:s}.'.format(disk.name))
       try:
         cls.az.compute_client.disks.delete(disk.resource_group_name, disk.name)
-      except CloudError as exception:
+      except azure_exceptions.CloudError as exception:
         raise RuntimeError('Could not complete cleanup: {0:s}'.format(
             str(exception)))
       logger.info('Disk {0:s} successfully deleted.'.format(disk.name))

--- a/tests/providers/azure/azure_e2e.py
+++ b/tests/providers/azure/azure_e2e.py
@@ -18,11 +18,13 @@ import typing
 import unittest
 
 from msrestazure.azure_exceptions import CloudError  # pylint: disable=import-error
-
-from libcloudforensics.providers.azure.internal.common import LOGGER
+from libcloudforensics import logging_utils
 from libcloudforensics.providers.azure.internal import account
 from libcloudforensics.providers.azure import forensics
 from tests.scripts import utils
+
+logging_utils.SetUpLogger(__name__)
+logger = logging_utils.GetLogger(__name__)
 
 
 class EndToEndTest(unittest.TestCase):
@@ -142,13 +144,13 @@ class EndToEndTest(unittest.TestCase):
   def tearDownClass(cls):
     # Delete the disks
     for disk in cls.disks:
-      LOGGER.info('Deleting disk: {0:s}.'.format(disk.name))
+      logger.info('Deleting disk: {0:s}.'.format(disk.name))
       try:
         cls.az.compute_client.disks.delete(disk.resource_group_name, disk.name)
       except CloudError as exception:
         raise RuntimeError('Could not complete cleanup: {0:s}'.format(
             str(exception)))
-      LOGGER.info('Disk {0:s} successfully deleted.'.format(disk.name))
+      logger.info('Disk {0:s} successfully deleted.'.format(disk.name))
 
 
 if __name__ == '__main__':

--- a/tests/providers/azure/azure_test.py
+++ b/tests/providers/azure/azure_test.py
@@ -23,9 +23,9 @@ from libcloudforensics.providers.azure import forensics
 
 # pylint: disable=line-too-long
 with mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials') as mock_creds:
-  # pylint: enable=line-too-long
   mock_creds.return_value = ('fake-subscription-id', mock.Mock())
   with mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup') as mock_resource:
+    # pylint: enable=line-too-long
     mock_resource.return_value = 'fake-resource-group'
     FAKE_ACCOUNT = account.AZAccount(
         'fake-resource-group',

--- a/tests/providers/azure/azure_test.py
+++ b/tests/providers/azure/azure_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for the azure module."""
+import os
 import typing
 import unittest
 import mock
@@ -23,10 +24,13 @@ from libcloudforensics.providers.azure import forensics
 # pylint: disable=line-too-long
 with mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials') as mock_creds:
   # pylint: enable=line-too-long
-  mock_creds.return_value = mock.Mock()
-  FAKE_ACCOUNT = account.AZAccount(
-      'fake-subscription-id'
-  )
+  mock_creds.return_value = ('fake-subscription-id', mock.Mock())
+  with mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup') as mock_resource:
+    mock_resource.return_value = 'fake-resource-group'
+    FAKE_ACCOUNT = account.AZAccount(
+        'fake-resource-group',
+        default_region='fake-region'
+    )
 
 FAKE_INSTANCE = compute.AZVirtualMachine(
     FAKE_ACCOUNT,
@@ -100,6 +104,23 @@ MOCK_LIST_DISKS = {
     'fake-boot-disk-name': FAKE_BOOT_DISK
 }
 
+MOCK_LIST_IDS = [
+    mock.Mock(subscription_id='fake-subscription-id-1'),
+    mock.Mock(subscription_id='fake-subscription-id-2')
+]
+
+MOCK_STORAGE_ACCOUNT = mock.Mock(id='fakestorageid')
+
+MOCK_LIST_KEYS = mock.Mock(
+    keys=[mock.Mock(key_name='key1', value='fake-key-value')])
+
+JSON_FILE = 'scripts/test_credentials.json'
+STARTUP_SCRIPT = 'scripts/startup.sh'
+
+MOCK_BLOB_PROPERTIES = mock.Mock()
+MOCK_BLOB_PROPERTIES.copy = mock.Mock()
+MOCK_BLOB_PROPERTIES.copy.status = 'success'
+
 
 class TestAccount(unittest.TestCase):
   """Test Azure account class."""
@@ -165,7 +186,6 @@ class TestAccount(unittest.TestCase):
     """Test that a particular instance from an account is retrieved."""
     mock_list_instances.return_value = MOCK_LIST_INSTANCES
     instance = FAKE_ACCOUNT.GetInstance('fake-vm-name')
-    mock_list_instances.assert_called_once()
     self.assertEqual('fake-vm-name', instance.name)
     self.assertEqual(
         '/a/b/c/fake-resource-group/fake-vm-name', instance.resource_id)
@@ -179,7 +199,6 @@ class TestAccount(unittest.TestCase):
     """Test that a particular disk from an account is retrieved."""
     mock_list_disks.return_value = MOCK_LIST_DISKS
     disk = FAKE_ACCOUNT.GetDisk('fake-disk-name')
-    mock_list_disks.assert_called_once()
     self.assertEqual('fake-disk-name', disk.name)
     self.assertEqual(
         '/a/b/c/fake-resource-group/fake-disk-name', disk.resource_id)
@@ -238,6 +257,77 @@ class TestAccount(unittest.TestCase):
         mock.ANY,
         sku='StandardSSD_LRS')
 
+  @mock.patch('azure.storage.blob._container_client.ContainerClient.create_container')
+  @mock.patch('azure.storage.blob._generated._azure_blob_storage.AzureBlobStorage.__init__')
+  @mock.patch('azure.storage.blob._blob_service_client.BlobServiceClient.get_blob_client')
+  @mock.patch('azure.storage.blob._blob_service_client.BlobServiceClient.get_container_client')
+  @mock.patch('azure.storage.blob._blob_service_client.BlobServiceClient.__init__')
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._DeleteStorageAccount')
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._CreateStorageAccount')
+  @mock.patch('azure.mgmt.compute.v2020_05_01.operations._disks_operations.DisksOperations.create_or_update')
+  @typing.no_type_check
+  def testCreateDiskFromSnapshotUri(self,
+                                    mock_create_disk,
+                                    mock_create_storage_account,
+                                    mock_delete_storage_account,
+                                    mock_blob_client,
+                                    mock_get_container,
+                                    mock_get_blob_client,
+                                    mock_blob_storage,
+                                    mock_create_container):
+    """Test that a disk can be created from a snapshot URI."""
+    mock_create_disk.return_value.done.return_value = True
+    mock_create_disk.return_value.result.return_value = MOCK_DISK_COPY
+    mock_create_storage_account.return_value = ('fake-account-id', 'fake-key')
+    mock_blob_client.return_value = None
+    mock_blob_storage.return_value = None
+    mock_get_container.return_value = mock.Mock()
+    mock_create_container.return_value = None
+    blob_properties = mock_get_blob_client.return_value.get_blob_properties
+    blob_properties.return_value = mock.Mock(copy=mock.Mock(status='success'))
+    mock_delete_storage_account.return_value = None
+
+    disk_from_snapshot_uri = FAKE_ACCOUNT.CreateDiskFromSnapshotURI(
+        FAKE_SNAPSHOT, 'fake-snapshot-uri')
+    #  hashlib.sha1('/a/b/c/fake-resource-group/fake_snapshot_name'.encode(
+    #     'utf-8')).hexdigest()[:23] = bff00b08549ba8b975b2e70
+    mock_create_storage_account.assert_called_with(
+        'bff00b08549ba8b975b2e70', region='fake-region')
+    self.assertIsInstance(disk_from_snapshot_uri, compute.AZDisk)
+    self.assertEqual(
+        'fake_snapshot_name_f4c186ac_copy', disk_from_snapshot_uri.name)
+    mock_create_disk.assert_called_with(
+        FAKE_SNAPSHOT.resource_group_name,
+        'fake_snapshot_name_f4c186ac_copy',
+        mock.ANY,
+        sku='Standard_LRS')
+
+  @mock.patch('azure.mgmt.resource.subscriptions.v2019_11_01.operations._subscriptions_operations.SubscriptionsOperations.list')
+  @typing.no_type_check
+  def testListSubscriptionIDs(self, mock_list):
+    """Test that subscription IDs are correctly listed"""
+    mock_list.return_value = MOCK_LIST_IDS
+    subscription_ids = FAKE_ACCOUNT.ListSubscriptionIDs()
+    self.assertEqual(2, len(subscription_ids))
+    self.assertEqual('fake-subscription-id-1', subscription_ids[0])
+
+  @mock.patch('azure.mgmt.storage.v2019_06_01.operations._storage_accounts_operations.StorageAccountsOperations.list_keys')
+  @mock.patch('azure.mgmt.storage.v2019_06_01.operations._storage_accounts_operations.StorageAccountsOperations.create')
+  @typing.no_type_check
+  def testCreateStorageAccount(self, mock_create, mock_list_keys):
+    """Test that a storage account is created and its information retrieved"""
+    # pylint: disable=protected-access
+    mock_create.return_value.result.return_value = MOCK_STORAGE_ACCOUNT
+    mock_list_keys.return_value = MOCK_LIST_KEYS
+    account_id, account_key = FAKE_ACCOUNT._CreateStorageAccount('fakename')
+    self.assertEqual('fakestorageid', account_id)
+    self.assertEqual('fake-key-value', account_key)
+
+    with self.assertRaises(ValueError):
+      _, _ = FAKE_ACCOUNT._CreateStorageAccount(
+          'fake-non-conform-name')
+    # pylint: enable=protected-access
+
 
 class TestCommon(unittest.TestCase):
   """Test Azure common file."""
@@ -255,6 +345,66 @@ class TestCommon(unittest.TestCase):
     disk_name = common.GenerateDiskName(
         FAKE_SNAPSHOT, disk_name_prefix='prefix')
     self.assertEqual('prefix_fake_snapshot_name_f4c186ac_copy', disk_name)
+
+  @mock.patch('msrestazure.azure_active_directory.ServicePrincipalCredentials.__init__')
+  @typing.no_type_check
+  def testGetCredentials(self, mock_azure_credentials):
+    """Test that credentials are parsed correctly / found."""
+
+    mock_azure_credentials.return_value = None
+
+    # If all environment variables are defined, things should work correctly
+    os.environ['AZURE_SUBSCRIPTION_ID'] = 'fake-subscription-id'
+    os.environ["AZURE_CLIENT_ID"] = 'fake-client-id'
+    os.environ["AZURE_CLIENT_SECRET"] = 'fake-client-secret'
+    os.environ["AZURE_TENANT_ID"] = 'fake-tenant-id'
+
+    subscription_id, _ = common.GetCredentials()
+    self.assertEqual('fake-subscription-id', subscription_id)
+    mock_azure_credentials.assert_called_with(
+        'fake-client-id', 'fake-client-secret', tenant='fake-tenant-id')
+
+    # If an environment variable is missing, a RuntimeError should be raised
+    del os.environ['AZURE_SUBSCRIPTION_ID']
+    with self.assertRaises(RuntimeError):
+      _, _ = common.GetCredentials()
+      mock_azure_credentials.assert_not_called()
+
+    # If a profile name is passed to the method, then it will look for a
+    # credential file (default path being ~/.azure/credentials.json). We can
+    # set a particular path by setting the AZURE_CREDENTIALS_PATH variable.
+
+    # If the file is not a valid json file, should raise a ValueError
+    os.environ['AZURE_CREDENTIALS_PATH'] = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.realpath(__file__)))), STARTUP_SCRIPT)
+    with self.assertRaises(ValueError):
+      _, _ = common.GetCredentials(profile_name='foo')
+      mock_azure_credentials.assert_not_called()
+
+    # If the file is correctly formatted, then things should work correctly
+    os.environ['AZURE_CREDENTIALS_PATH'] = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.realpath(__file__)))), JSON_FILE)
+    subscription_id, _ = common.GetCredentials(
+        profile_name='test_profile_name')
+    self.assertEqual(
+        'fake-subscription-id-from-credential-file', subscription_id)
+    mock_azure_credentials.assert_called_with(
+        'fake-client-id-from-credential-file',
+        'fake-client-secret-from-credential-file',
+        tenant='fake-tenant-id-from-credential-file')
+
+    # If the profile name does not exist, should raise a ValueError
+    with self.assertRaises(ValueError):
+      _, _ = common.GetCredentials(profile_name='foo')
+      mock_azure_credentials.assert_not_called()
+
+    # If the profile name exists but there are missing entries, should raise
+    # a ValueError
+    with self.assertRaises(ValueError):
+      _, _ = common.GetCredentials(profile_name='incomplete_profile_name')
+      mock_azure_credentials.assert_not_called()
 
 
 class TestAZVirtualMachine(unittest.TestCase):
@@ -324,7 +474,9 @@ class TestForensics(unittest.TestCase):
   """Test Azure forensics file."""
   # pylint: disable=line-too-long
 
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZSnapshot.Delete')
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.Snapshot')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetDisk')
@@ -339,11 +491,13 @@ class TestForensics(unittest.TestCase):
                           mock_get_disk,
                           mock_snapshot,
                           mock_snapshot_delete,
-                          mock_credentials):
+                          mock_list_subscription_ids,
+                          mock_credentials,
+                          mock_resource_group):
     """Test that a disk copy is correctly created.
 
-    CreateDiskCopy(zone, instance_name='fake-vm-name'). This should grab
-    the boot disk of the instance.
+    CreateDiskCopy(zone, instance_name='fake-vm-name', region='fake-region').
+    This should grab the boot disk of the instance.
     """
     mock_create_disk.return_value.done.return_value = True
     mock_create_disk.return_value.result.return_value = MOCK_DISK_COPY
@@ -351,10 +505,14 @@ class TestForensics(unittest.TestCase):
     mock_get_boot_disk.return_value = FAKE_BOOT_DISK
     mock_snapshot.return_value = FAKE_SNAPSHOT
     mock_snapshot_delete.return_value = None
-    mock_credentials.return_value = mock.Mock()
+    mock_list_subscription_ids.return_value = ['fake-subscription-id']
+    mock_credentials.return_value = ('fake-subscription-id', mock.Mock())
+    mock_resource_group.return_value = 'fake-resource-group'
 
     disk_copy = forensics.CreateDiskCopy(
-        FAKE_ACCOUNT.subscription_id, instance_name=FAKE_INSTANCE.name)
+        FAKE_ACCOUNT.default_resource_group_name,
+        instance_name=FAKE_INSTANCE.name,
+        region='fake-region')
     mock_get_instance.assert_called_once()
     mock_get_instance.assert_called_with('fake-vm-name')
     mock_get_boot_disk.assert_called_once()
@@ -362,7 +520,9 @@ class TestForensics(unittest.TestCase):
     self.assertIsInstance(disk_copy, compute.AZDisk)
     self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_copy.name)
 
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZSnapshot.Delete')
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.Snapshot')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetDisk')
@@ -377,21 +537,27 @@ class TestForensics(unittest.TestCase):
                           mock_get_disk,
                           mock_snapshot,
                           mock_snapshot_delete,
-                          mock_credentials):
+                          mock_list_subscription_ids,
+                          mock_credentials,
+                          mock_resource_group):
     """Test that a disk copy is correctly created.
 
-    CreateDiskCopy(zone, disk_name='fake-disk-name'). This should grab
-    the disk 'fake-disk-name'."""
+    CreateDiskCopy(zone, disk_name='fake-disk-name', region='fake-region').
+    This should grab the disk 'fake-disk-name'."""
     mock_create_disk.return_value.done.return_value = True
     mock_create_disk.return_value.result.return_value = MOCK_DISK_COPY
     mock_get_instance.return_value = FAKE_INSTANCE
     mock_get_disk.return_value = FAKE_DISK
     mock_snapshot.return_value = FAKE_SNAPSHOT
     mock_snapshot_delete.return_value = None
-    mock_credentials.return_value = mock.Mock()
+    mock_list_subscription_ids.return_value = ['fake-subscription-id']
+    mock_credentials.return_value = ('fake-subscription-id', mock.Mock())
+    mock_resource_group.return_value = 'fake-resource-group'
 
     disk_copy = forensics.CreateDiskCopy(
-        FAKE_ACCOUNT.subscription_id, disk_name=FAKE_DISK.name)
+        FAKE_ACCOUNT.default_resource_group_name,
+        disk_name=FAKE_DISK.name,
+        region='fake-region')
     mock_get_instance.assert_not_called()
     mock_get_boot_disk.assert_not_called()
     mock_get_disk.assert_called_once()
@@ -399,14 +565,18 @@ class TestForensics(unittest.TestCase):
     self.assertIsInstance(disk_copy, compute.AZDisk)
     self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_copy.name)
 
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
+  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListDisks')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListInstances')
   @typing.no_type_check
   def testCreateDiskCopy3(self,
                           mock_list_instances,
                           mock_list_disk,
-                          mock_credentials):
+                          mock_list_subscription_ids,
+                          mock_credentials,
+                          mock_resource_group):
     """Test that a disk copy is correctly created.
 
     The first call should raise a RuntimeError in GetInstance as we are
@@ -414,15 +584,21 @@ class TestForensics(unittest.TestCase):
     RuntimeError in GetDisk as we are querying a non-existent disk."""
     mock_list_instances.return_value = {}
     mock_list_disk.return_value = {}
-    mock_credentials.return_value = mock.Mock()
+    mock_list_subscription_ids.return_value = ['fake-subscription-id']
+    mock_credentials.return_value = ('fake-subscription-id', mock.Mock())
+    mock_resource_group.return_value = 'fake-resource-group'
 
     with self.assertRaises(RuntimeError):
       forensics.CreateDiskCopy(
-          FAKE_ACCOUNT.subscription_id, instance_name='non-existent-vm-name')
+          FAKE_ACCOUNT.default_resource_group_name,
+          instance_name='non-existent-vm-name',
+          region='fake-region')
 
     with self.assertRaises(RuntimeError):
       forensics.CreateDiskCopy(
-          FAKE_ACCOUNT.subscription_id, disk_name='non-existent-disk-name')
+          FAKE_ACCOUNT.default_resource_group_name,
+          disk_name='non-existent-disk-name',
+          region='fake-region')
 
 
 if __name__ == '__main__':

--- a/tests/scripts/test_credentials.json
+++ b/tests/scripts/test_credentials.json
@@ -1,0 +1,10 @@
+{
+  "test_profile_name": {
+     "subscriptionId": "fake-subscription-id-from-credential-file",
+     "tenantId": "fake-tenant-id-from-credential-file",
+     "clientId": "fake-client-id-from-credential-file",
+     "clientSecret": "fake-client-secret-from-credential-file"
+  },
+  "incomplete_profile_name": {
+  }
+}


### PR DESCRIPTION
Some changes following #174 

- Authentication is now more flexible. People can use environment variables or define their access keys in a `.json` file that is parsed. The library looks by default in `~/.azure/credentials.json` but it is also possible to pass an absolute path to the `AZURE_CREDENTIALS_PATH` environment variable. The advantage of the latter approach is that it replicates things you can do in AWS (define auth profiles).

- If the specified resource group name does not exists in the subscription, it will be automatically created.

- Disk copy functionality now allows you to select a different region for the copy to be created in, rather than using the region in which the source disk is.

- Disk copy functionality now allows you to make the copy in a different subscription within an Azure account.

- Disk copy functionality now allows you to make the copy in an entirely different Azure account:
  - In Azure, snapshots can be shared by generating a SAS (Shared Access Signature) downloadable link of the snapshot. Anyone with this link can download a `.vhd` copy of the snapshot.
  - As it is not possible to directly create a new disk out of a SAS link, the library generates (in the destination account) a temporary Azure Storage Account and corresponding Blob Container, and downloads the `.vhd` there.
  - As a third step, a new disk is created from the imported snapshot stored in the Azure Storage Account (in the destination account).
  - Things are cleaned up afterwards: all intermediary snapshots, storage account, SAS links.

Note that this complicated process is also necessary when creating a disk copy in a different region within the same account, as there is no other workaround at the moment.

The CLI tool, unit tests and end-to-end tests have all been updated to reflect these changes.

Signed-off-by: Theo Giovanna <gtheo@google.com>