### PR TITLE
Add AWS CLI flag to generate an SSH key for startvm

### DIFF
--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -135,13 +135,21 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
       attach_volumes.append(attach)
       device_letter = device_letter + 1
 
+  key_name = args.ssh_key_name
+  if args.generate_ssh_key_pair:
+    print('Generating SSH key pair for the analysis VM.')
+    aws_account = account.AWSAccount(args.zone)
+    key_name, private_key = aws_account.GenerateSSHKeyPair(args.instance_name)
+    print('Created key pair {0:s} in AWS. Your private key is: \n{1:s}'.format(
+        key_name, private_key))
+
   print('Starting analysis VM...')
   vm = forensics.StartAnalysisVm(vm_name=args.instance_name,
                                  default_availability_zone=args.zone,
                                  boot_volume_size=int(args.boot_volume_size),
                                  cpu_cores=int(args.cpu_cores),
                                  ami=args.ami,
-                                 ssh_key_name=args.ssh_key_name,
+                                 ssh_key_name=key_name,
                                  attach_volumes=attach_volumes,
                                  dst_profile=args.dst_profile)
 

--- a/examples/aws_cli.py
+++ b/examples/aws_cli.py
@@ -18,6 +18,7 @@
 """Demo CLI tool for AWS."""
 
 import json
+import os
 
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -140,8 +141,11 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
     print('Generating SSH key pair for the analysis VM.')
     aws_account = account.AWSAccount(args.zone)
     key_name, private_key = aws_account.GenerateSSHKeyPair(args.instance_name)
-    print('Created key pair {0:s} in AWS. Your private key is: \n{1:s}'.format(
-        key_name, private_key))
+    path = os.path.join(os.getcwd(), key_name + '.pem')
+    with open(path, 'w') as f:
+      f.write(private_key)
+    print('Created key pair {0:s} in AWS. Your private key is saved in: '
+          '{1:s}'.format(key_name, path))
 
   print('Starting analysis VM...')
   vm = forensics.StartAnalysisVm(vm_name=args.instance_name,

--- a/libcloudforensics/providers/gcp/internal/gke.py
+++ b/libcloudforensics/providers/gcp/internal/gke.py
@@ -56,8 +56,8 @@ class GoogleKubernetesEngine:
     """ Gets the details of a specific cluster.
 
     Args:
-      name (str): The name (project, location, cluster) of the cluster to retrieve.
-          Specified in the format `projects/*/locations/*/clusters/*`.
+      name (str): The name (project, location, cluster) of the cluster to
+          retrieve. Specified in the format `projects/*/locations/*/clusters/*`.
           For regional cluster: `/locations/[GCP_REGION]`.
           For zonal cluster: `/locations/[GCP_ZONE]`.
 


### PR DESCRIPTION
Add a flag to the AWS CLI so that a new SSH key pair gets added to the analysis account when using `startvm`. 
The corresponding private key is saved to disk once the process completes. The generated key pair is associated to the bootstrapped vm.

Usage:

```
libcloudforensics aws us-east-2b startvm <vm_name> --generate_ssh_key_pair

Generating SSH key pair for the analysis VM.
Created key pair <vm_name>-867d966b65a5f9492a55-ssh in AWS. Your private key is saved in <path to key>.pem 
Starting analysis VM...
[2020-07-21 19:12:36,707] [libcloudforensics.providers.aws.forensics] INFO     No AMI provided, fetching one for Ubuntu 18.04
[2020-07-21 19:12:38,574] [libcloudforensics.providers.aws.forensics] INFO     Starting analysis VM <vm_name>
[TRUNCATED]
```

Note: had to modify and unrelated GKE file to satisfy my local linter.

Signed-off-by: Theo Giovanna <gtheo@google.com>