### PR TITLE
Default disk type to source disk type in CreateDiskCopy

### DIFF
--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -30,7 +30,7 @@ def CreateDiskCopy(
     resource_group_name: str,
     instance_name: Optional[str] = None,
     disk_name: Optional[str] = None,
-    disk_type: str = 'Standard_LRS',
+    disk_type: Optional[str] = None,
     region: str = 'eastus',
     src_profile: Optional[str] = None,
     dst_profile: Optional[str] = None) -> 'compute.AZDisk':
@@ -47,7 +47,7 @@ def CreateDiskCopy(
         then instance_name needs to be set and the boot disk will be copied.
     disk_type (str): Optional. The sku name for the disk to create. Can be
         Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
-        default value is Standard_LRS.
+        default behavior is to use the same disk type as the source disk.
     region (str): Optional. The region in which to create the disk copy.
         Default is eastus.
     src_profile (str): Optional. The name of the source profile to use for the
@@ -88,6 +88,10 @@ def CreateDiskCopy(
       disk_to_copy = instance.GetBootDisk()
     logger.info('Disk copy of {0:s} started...'.format(
         disk_to_copy.name))
+
+    if not disk_type:
+      disk_type = disk_to_copy.GetDiskType()
+
     snapshot = disk_to_copy.Snapshot()
 
     subscription_ids = src_account.ListSubscriptionIDs()

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -239,7 +239,8 @@ class AZAccount:
         'creation_data': {
             'sourceResourceId': snapshot.resource_id,
             'create_option': models.DiskCreateOption.copy
-        }
+        },
+        'sku': {'name': disk_type}
     }
 
     try:
@@ -247,8 +248,7 @@ class AZAccount:
       request = self.compute_client.disks.create_or_update(
           self.default_resource_group_name,
           disk_name,
-          creation_data,
-          sku=disk_type)
+          creation_data)
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking disk status again
       disk = request.result()
@@ -354,7 +354,8 @@ class AZAccount:
             'source_uri': copied_blob.url,
             'storage_account_id': storage_account_id,
             'create_option': models.DiskCreateOption.import_enum
-        }
+        },
+        'sku': {'name': disk_type}
     }
 
     try:
@@ -362,8 +363,7 @@ class AZAccount:
       request = self.compute_client.disks.create_or_update(
           self.default_resource_group_name,
           disk_name,
-          creation_data,
-          sku=disk_type)
+          creation_data)
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking disk status again
       disk = request.result()

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -240,6 +240,17 @@ class AZDisk(AZComputeResource):
                       snapshot.location,
                       self)
 
+  def GetDiskType(self) -> str:
+    """Return the SKU disk type.
+
+    Returns:
+      str: The SKU disk type.
+    """
+    disk = self.az_account.compute_client.disks.get(
+        self.resource_group_name, self.name)
+    disk_type = disk.sku.name  # type: str
+    return disk_type
+
 
 class AZSnapshot(AZComputeResource):
   """Class that represents Azure snapshots.

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -37,7 +37,7 @@ def CreateDiskCopy(
     zone: str,
     instance_name: Optional[str] = None,
     disk_name: Optional[str] = None,
-    disk_type: str = 'pd-standard') -> 'compute.GoogleComputeDisk':
+    disk_type: Optional[str] = None) -> 'compute.GoogleComputeDisk':
   """Creates a copy of a Google Compute Disk.
 
   Args:
@@ -48,8 +48,8 @@ def CreateDiskCopy(
     disk_name (str): Optional. Name of the disk to copy. If None,
         instance_name must be specified and the boot disk will be copied.
     disk_type (str): Optional. URL of the disk type resource describing
-        which disk type to use to create the disk. Default is pd-standard. Use
-        pd-ssd to have a SSD disk.
+        which disk type to use to create the disk. The default behavior is to
+        use the same disk type as the source disk.
 
   Returns:
     GoogleComputeDisk: A Google Compute Disk object.
@@ -72,6 +72,9 @@ def CreateDiskCopy(
     elif instance_name:
       instance = src_project.compute.GetInstance(instance_name)
       disk_to_copy = instance.GetBootDisk()
+
+    if not disk_type:
+      disk_type = disk_to_copy.GetDiskType()
 
     logger.info('Disk copy of {0:s} started...'.format(
         disk_to_copy.name))

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -917,6 +917,17 @@ class GoogleComputeDisk(compute_base_resource.GoogleComputeBaseResource):
     self.BlockOperation(response, zone=self.zone)
     return GoogleComputeSnapshot(disk=self, name=snapshot_name)
 
+  def GetDiskType(self) -> str:
+    """Return the disk type.
+
+    Returns:
+      str: The disk type.
+    """
+    # 'type': https://www.googleapis.com/compute/v1/projects/<>/zones/us
+    # -central1-a/diskTypes/pd-standard
+    disk_type = self.GetOperation()['type'].split('/')[-1]  # type: str
+    return disk_type
+
 
 class GoogleComputeSnapshot(compute_base_resource.GoogleComputeBaseResource):
   """Class representing a Compute Engine Snapshot.

--- a/tests/providers/azure/azure_test.py
+++ b/tests/providers/azure/azure_test.py
@@ -18,6 +18,8 @@ import typing
 import unittest
 import mock
 
+from azure.mgmt.compute.v2020_05_01 import models  # pylint: disable=import-error
+
 from libcloudforensics.providers.azure.internal import account, compute, common, monitoring  # pylint:disable=line-too-long
 from libcloudforensics.providers.azure import forensics
 
@@ -234,8 +236,7 @@ class TestAccount(unittest.TestCase):
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
         'fake_snapshot_name_f4c186ac_copy',
-        mock.ANY,
-        sku='Standard_LRS')
+        mock.ANY)
 
     # CreateDiskFromSnapshot(
     #     snapshot=FAKE_SNAPSHOT,
@@ -246,8 +247,7 @@ class TestAccount(unittest.TestCase):
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
         'new-forensics-disk',
-        mock.ANY,
-        sku='Standard_LRS')
+        mock.ANY)
 
     # CreateDiskFromSnapshot(
     #     snapshot=FAKE_SNAPSHOT, disk_name=None, disk_name_prefix='prefix')
@@ -256,18 +256,26 @@ class TestAccount(unittest.TestCase):
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
         'prefix_fake_snapshot_name_f4c186ac_copy',
-        mock.ANY,
-        sku='Standard_LRS')
+        mock.ANY)
 
     # CreateDiskFromSnapshot(
     #     snapshot=FAKE_SNAPSHOT, disk_type='StandardSSD_LRS')
+    expected_args = {
+        'location': 'fake-region',
+        'creation_data': {
+            'sourceResourceId': '/a/b/c/fake-resource-group/fake_snapshot_name',
+            'create_option': models.DiskCreateOption.copy
+        },
+        'sku': {
+            'name': 'StandardSSD_LRS'
+        }
+    }
     FAKE_ACCOUNT.CreateDiskFromSnapshot(
         FAKE_SNAPSHOT, disk_type='StandardSSD_LRS')
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
         'fake_snapshot_name_f4c186ac_copy',
-        mock.ANY,
-        sku='StandardSSD_LRS')
+        expected_args)
 
   @mock.patch('azure.storage.blob._container_client.ContainerClient.create_container')
   @mock.patch('azure.storage.blob._generated._azure_blob_storage.AzureBlobStorage.__init__')
@@ -311,8 +319,7 @@ class TestAccount(unittest.TestCase):
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
         'fake_snapshot_name_f4c186ac_copy',
-        mock.ANY,
-        sku='Standard_LRS')
+        mock.ANY)
 
   @mock.patch('azure.mgmt.resource.subscriptions.v2019_11_01.operations._subscriptions_operations.SubscriptionsOperations.list')
   @typing.no_type_check
@@ -528,8 +535,9 @@ class TestMonitoring(unittest.TestCase):
 
 class TestForensics(unittest.TestCase):
   """Test Azure forensics file."""
-  # pylint: disable=line-too-long
+  # pylint: disable=line-too-long, too-many-arguments
 
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.GetDiskType')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
@@ -549,7 +557,8 @@ class TestForensics(unittest.TestCase):
                           mock_snapshot_delete,
                           mock_list_subscription_ids,
                           mock_credentials,
-                          mock_resource_group):
+                          mock_resource_group,
+                          mock_disk_type):
     """Test that a disk copy is correctly created.
 
     CreateDiskCopy(zone, instance_name='fake-vm-name', region='fake-region').
@@ -564,6 +573,7 @@ class TestForensics(unittest.TestCase):
     mock_list_subscription_ids.return_value = ['fake-subscription-id']
     mock_credentials.return_value = ('fake-subscription-id', mock.Mock())
     mock_resource_group.return_value = 'fake-resource-group'
+    mock_disk_type.return_value = 'fake-disk-type'
 
     disk_copy = forensics.CreateDiskCopy(
         FAKE_ACCOUNT.default_resource_group_name,
@@ -576,6 +586,7 @@ class TestForensics(unittest.TestCase):
     self.assertIsInstance(disk_copy, compute.AZDisk)
     self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_copy.name)
 
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.GetDiskType')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
@@ -595,7 +606,8 @@ class TestForensics(unittest.TestCase):
                           mock_snapshot_delete,
                           mock_list_subscription_ids,
                           mock_credentials,
-                          mock_resource_group):
+                          mock_resource_group,
+                          mock_disk_type):
     """Test that a disk copy is correctly created.
 
     CreateDiskCopy(zone, disk_name='fake-disk-name', region='fake-region').
@@ -609,6 +621,7 @@ class TestForensics(unittest.TestCase):
     mock_list_subscription_ids.return_value = ['fake-subscription-id']
     mock_credentials.return_value = ('fake-subscription-id', mock.Mock())
     mock_resource_group.return_value = 'fake-resource-group'
+    mock_disk_type.return_value = 'fake-disk-type'
 
     disk_copy = forensics.CreateDiskCopy(
         FAKE_ACCOUNT.default_resource_group_name,
@@ -621,6 +634,7 @@ class TestForensics(unittest.TestCase):
     self.assertIsInstance(disk_copy, compute.AZDisk)
     self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_copy.name)
 
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.GetDiskType')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
   @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
@@ -632,7 +646,8 @@ class TestForensics(unittest.TestCase):
                           mock_list_disk,
                           mock_list_subscription_ids,
                           mock_credentials,
-                          mock_resource_group):
+                          mock_resource_group,
+                          mock_disk_type):
     """Test that a disk copy is correctly created.
 
     The first call should raise a RuntimeError in GetInstance as we are
@@ -643,6 +658,7 @@ class TestForensics(unittest.TestCase):
     mock_list_subscription_ids.return_value = ['fake-subscription-id']
     mock_credentials.return_value = ('fake-subscription-id', mock.Mock())
     mock_resource_group.return_value = 'fake-resource-group'
+    mock_disk_type.return_value = 'fake-disk-type'
 
     with self.assertRaises(RuntimeError) as error:
       forensics.CreateDiskCopy(

--- a/tests/providers/gcp/gcp_test.py
+++ b/tests/providers/gcp/gcp_test.py
@@ -853,6 +853,7 @@ class GCPTest(unittest.TestCase):
   # pylint: disable=line-too-long
 
   @typing.no_type_check
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeDisk.GetDiskType')
   @mock.patch('libcloudforensics.providers.gcp.internal.common.GoogleCloudComputeClient.BlockOperation')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.GetDisk')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.GetBootDisk')
@@ -863,7 +864,8 @@ class GCPTest(unittest.TestCase):
                           mock_get_instance,
                           mock_get_boot_disk,
                           mock_get_disk,
-                          mock_block_operation):
+                          mock_block_operation,
+                          mock_disk_type):
     """Test that a disk from a remote project is duplicated and attached to
     an analysis project. """
     instances = mock_gce_api.return_value.instances.return_value.aggregatedList
@@ -871,6 +873,7 @@ class GCPTest(unittest.TestCase):
     mock_get_instance.return_value = FAKE_INSTANCE
     mock_get_boot_disk.return_value = FAKE_BOOT_DISK
     mock_block_operation.return_value = None
+    mock_disk_type.return_value = 'fake-disk-type'
 
     # create_disk_copy(
     #     src_proj,
@@ -890,6 +893,7 @@ class GCPTest(unittest.TestCase):
     self.assertTrue(new_disk.name.endswith('-copy'))
 
   @typing.no_type_check
+  @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeDisk.GetDiskType')
   @mock.patch('libcloudforensics.providers.gcp.internal.common.GoogleCloudComputeClient.BlockOperation')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleComputeInstance.GetBootDisk')
   @mock.patch('libcloudforensics.providers.gcp.internal.compute.GoogleCloudCompute.GetDisk')
@@ -898,13 +902,15 @@ class GCPTest(unittest.TestCase):
                           mock_gce_api,
                           mock_get_disk,
                           mock_get_boot_disk,
-                          mock_block_operation):
+                          mock_block_operation,
+                          mock_disk_type):
     """Test that a disk from a remote project is duplicated and attached to
     an analysis project. """
     instances = mock_gce_api.return_value.instances.return_value.aggregatedList
     instances.return_value.execute.return_value = MOCK_INSTANCES_AGGREGATED
     mock_get_disk.return_value = FAKE_DISK
     mock_block_operation.return_value = None
+    mock_disk_type.return_value = 'fake-disk-type'
 
     # create_disk_copy(
     #     src_proj,

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -202,8 +202,9 @@ def Main() -> None:
                                 'instance will be copied.', None),
                 ('--disk_type', 'The SKU name for the disk to create. '
                                 'Can be Standard_LRS, Premium_LRS, '
-                                'StandardSSD_LRS, or UltraSSD_LRS. Default is '
-                                'Standard_LRS', 'Standard_LRS'),
+                                'StandardSSD_LRS, or UltraSSD_LRS. The default '
+                                'behavior is to use the same disk type as '
+                                'the source disk.', None),
                 ('--region', 'The region in which to create the disk copy. If '
                              'not provided, the disk copy will be created in '
                              'the "eastus" region.', 'eastus'),
@@ -263,7 +264,10 @@ def Main() -> None:
                 ('--disk_name', 'Name of the disk to copy. If none specified, '
                                 'then --instance_name must be specified and '
                                 'the boot disk of the instance will be copied.',
-                 None)
+                 None),
+                ('--disk_type', 'Type of disk. Can be pd-standard or pd-ssd. '
+                                'The default behavior is to use the same disk '
+                                'type as the source disk.', None)
             ])
   AddParser('gcp', gcp_subparsers, 'startvm', 'Start a forensic analysis VM.',
             args=[
@@ -271,7 +275,8 @@ def Main() -> None:
                  ''),
                 ('zone', 'Zone to create the instance in.', ''),
                 ('--disk_size', 'Size of disk in GB.', '50'),
-                ('--disk_type', 'Type of disk.', 'pd-ssd'),
+                ('--disk_type', 'Type of disk. Can be pd-standard or pd-ssd. '
+                                'The default value is pd-ssd.', 'pd-ssd'),
                 ('--cpu_cores', 'Instance CPU core count.', '4'),
                 ('--attach_disks', 'Comma seperated list of disk names '
                                    'to attach.', None)

--- a/tools/gcp_cli.py
+++ b/tools/gcp_cli.py
@@ -78,7 +78,8 @@ def CreateDiskCopy(args: 'argparse.Namespace') -> None:
                                   args.dst_project,
                                   args.zone,
                                   instance_name=args.instance_name,
-                                  disk_name=args.disk_name)
+                                  disk_name=args.disk_name,
+                                  disk_type=args.disk_type)
 
   logger.info('Disk copy completed.')
   logger.info('Name: {0:s}'.format(disk.name))


### PR DESCRIPTION
- Closes #210 
- Opened #220 as this feature is actually missing in AWS

Signed-off-by: Theo Giovanna <gtheo@google.com>