### PR TITLE
Add support for volume type selection in AWS

### DIFF
--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -420,6 +420,7 @@ class AWSAccount:
       snapshot: ebs.AWSSnapshot,
       volume_name: Optional[str] = None,
       volume_name_prefix: Optional[str] = None,
+      volume_type: str = 'gp2',
       kms_key_id: Optional[str] = None,
       tags: Optional[Dict[str, str]] = None) -> ebs.AWSVolume:
     """Create a new volume based on a snapshot.
@@ -428,6 +429,9 @@ class AWSAccount:
       snapshot (AWSSnapshot): Snapshot to use.
       volume_name (str): Optional. String to use as new volume name.
       volume_name_prefix (str): Optional. String to prefix the volume name with.
+      volume_type (str): Optional. The volume type for the volume to create.
+          Can be one of 'standard'|'io1'|'gp2'|'sc1'|'st1'. The default is
+          'gp2'.
       kms_key_id (str): Optional. A KMS key id to encrypt the volume with.
       tags (Dict[str, str]): Optional. A dictionary of tags to add to the
           volume, for example {'TicketID': 'xxx'}. An entry for the volume
@@ -457,11 +461,19 @@ class AWSAccount:
     create_volume_args = {
         'AvailabilityZone': snapshot.availability_zone,
         'SnapshotId': snapshot.snapshot_id,
-        'TagSpecifications': [common.CreateTags(common.VOLUME, tags)]
+        'TagSpecifications': [common.CreateTags(common.VOLUME, tags)],
+        'VolumeType': volume_type
     }
     if kms_key_id:
       create_volume_args['Encrypted'] = True
       create_volume_args['KmsKeyId'] = kms_key_id
+    if volume_type == 'io1':
+      # If using the io1 volume type, we must specify Iops, see
+      # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/
+      # services/ec2.html#EC2.Client.create_volume. io1 volumes allow for a
+      # ratio of 50 IOPS per 1 GiB.
+      create_volume_args['Iops'] = self.ResourceApi(
+          common.EC2_SERVICE).Snapshot(snapshot.snapshot_id).volume_size * 50
     try:
       volume = client.create_volume(**create_volume_args)
       volume_id = volume['VolumeId']
@@ -489,6 +501,7 @@ class AWSAccount:
       boot_volume_size: int,
       ami: str,
       cpu_cores: int,
+      boot_volume_type: str = 'gp2',
       packages: Optional[List[str]] = None,
       ssh_key_name: Optional[str] = None,
       tags: Optional[Dict[str, str]] = None) -> Tuple[ec2.AWSInstance, bool]:
@@ -499,6 +512,9 @@ class AWSAccount:
       boot_volume_size (int): The size of the analysis VM boot volume (in GB).
       ami (str): The Amazon Machine Image ID to use to create the VM.
       cpu_cores (int): Number of CPU cores for the analysis VM.
+      boot_volume_type (str): Optional. The volume type for the boot volume
+          of the VM. Can be one of 'standard'|'io1'|'gp2'|'sc1'|'st1'. The
+          default is 'gp2'.
       packages (List[str]): Optional. List of packages to install in the VM.
       ssh_key_name (str): Optional. A SSH key pair name linked to the AWS
           account to associate with the VM. If none provided, the VM can only
@@ -547,7 +563,8 @@ class AWSAccount:
     client = self.ClientApi(common.EC2_SERVICE)
     vm_args = {
         'BlockDeviceMappings':
-            [self._GetBootVolumeConfigByAmi(ami, boot_volume_size)],
+            [self._GetBootVolumeConfigByAmi(
+                ami, boot_volume_size, boot_volume_type)],
         'ImageId': ami,
         'MinCount': 1,
         'MaxCount': 1,
@@ -735,12 +752,14 @@ class AWSAccount:
 
   def _GetBootVolumeConfigByAmi(self,
                                 ami: str,
-                                boot_volume_size: int) -> Dict[str, Any]:
+                                boot_volume_size: int,
+                                boot_volume_type: str) -> Dict[str, Any]:
     """Return a boot volume configuration for a given AMI and boot volume size.
 
     Args:
       ami (str): The Amazon Machine Image ID.
       boot_volume_size (int): Size of the boot volume, in GB.
+      boot_volume_type (str): Type of the boot volume.
 
     Returns:
       Dict[str, str|Dict]]: A BlockDeviceMappings configuration for the
@@ -765,6 +784,13 @@ class AWSAccount:
     block_device_mapping = image['Images'][0]['BlockDeviceMappings'][0]  # type: Dict[str, Any]
     # pylint: enable=line-too-long
     block_device_mapping['Ebs']['VolumeSize'] = boot_volume_size
+    block_device_mapping['Ebs']['VolumeType'] = boot_volume_type
+    if boot_volume_type == 'io1':
+      # If using the io1 volume type, we must specify Iops, see
+      # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/
+      # services/ec2.html#EC2.Client.create_volume. io1 volumes allow for a
+      # ratio of 50 IOPS per 1 GiB.
+      block_device_mapping['Ebs']['Iops'] = boot_volume_size * 50
     return block_device_mapping
 
   def ListImages(

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -441,9 +441,14 @@ class AWSAccount:
       AWSVolume: An AWS EBS Volume.
 
     Raises:
-      ValueError: If the volume name does not comply with the RegEx.
+      ValueError: If the volume name does not comply with the RegEx,
+          or if the volume type is invalid.
       RuntimeError: If the volume could not be created.
     """
+
+    if volume_type not in ['standard', 'io1', 'gp2', 'sc1', 'st1']:
+      raise ValueError('Volume type must be one of [standard, io1, gp2, sc1, '
+                       'st1]. Got: {0:s}'.format(volume_type))
 
     if not volume_name:
       volume_name = self._GenerateVolumeName(

--- a/libcloudforensics/providers/aws/internal/ebs.py
+++ b/libcloudforensics/providers/aws/internal/ebs.py
@@ -162,6 +162,16 @@ class AWSVolume(AWSElasticBlockStore):
       raise RuntimeError('Could not delete volume {0:s}: {1:s}'.format(
           self.volume_id, str(exception)))
 
+  def GetVolumeType(self) -> str:
+    """Return the volume type.
+
+    Returns:
+      str: The volume type.
+    """
+    client = self.aws_account.ResourceApi(common.EC2_SERVICE)
+    volume_type = client.Volume(self.volume_id).volume_type  # type: str
+    return volume_type
+
 
 class AWSSnapshot(AWSElasticBlockStore):
   """Class representing an AWS EBS snapshot.

--- a/tests/providers/aws/aws_test.py
+++ b/tests/providers/aws/aws_test.py
@@ -370,6 +370,12 @@ class AWSAccountTest(unittest.TestCase):
     self.assertEqual(
         'prefix-fake-snapshot-d69d57c3-copy', volume_from_snapshot.name)
 
+    with self.assertRaises(ValueError) as error:
+      FAKE_AWS_ACCOUNT.CreateVolumeFromSnapshot(
+          FAKE_SNAPSHOT, volume_type='invalid-volume-type')
+    self.assertEqual('Volume type must be one of [standard, io1, gp2, sc1, '
+                     'st1]. Got: invalid-volume-type', str(error.exception))
+
   @typing.no_type_check
   @mock.patch('libcloudforensics.scripts.utils.ReadStartupScript')
   @mock.patch('libcloudforensics.providers.aws.internal.account.AWSAccount.GetInstancesByName')
@@ -582,7 +588,7 @@ class AWSTest(unittest.TestCase):
     mock_account.return_value = 'fake-account-id'
     mock_get_volume.return_value = FAKE_VOLUME
     mock_snapshot.return_value = FAKE_SNAPSHOT
-    mock_volume_type.return_value = 'fake-volume-type'
+    mock_volume_type.return_value = 'standard'
     mock_loader.return_value = None
 
     # CreateVolumeCopy(zone, volume_id='fake-volume-id'). This should grab
@@ -618,7 +624,7 @@ class AWSTest(unittest.TestCase):
     mock_get_instance.return_value = FAKE_INSTANCE
     mock_get_volume.return_value = FAKE_BOOT_VOLUME
     mock_snapshot.return_value = FAKE_SNAPSHOT
-    mock_volume_type.return_value = 'fake-volume-type'
+    mock_volume_type.return_value = 'standard'
     mock_loader.return_value = None
 
     # CreateVolumeCopy(zone, instance='fake-instance-id'). This should grab

--- a/tools/aws_cli.py
+++ b/tools/aws_cli.py
@@ -81,6 +81,7 @@ def CreateVolumeCopy(args: 'argparse.Namespace') -> None:
                                            dst_zone=args.dst_zone,
                                            instance_id=args.instance_id,
                                            volume_id=args.volume_id,
+                                           volume_type=args.volume_type,
                                            src_profile=args.src_profile,
                                            dst_profile=args.dst_profile,
                                            tags=tags)
@@ -157,6 +158,7 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
   vm = forensics.StartAnalysisVm(vm_name=args.instance_name,
                                  default_availability_zone=args.zone,
                                  boot_volume_size=int(args.boot_volume_size),
+                                 boot_volume_type=args.boot_volume_type,
                                  cpu_cores=int(args.cpu_cores),
                                  ami=args.ami,
                                  ssh_key_name=key_name,

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -128,6 +128,10 @@ def Main() -> None:
                                 'copy. If none specified, then --instance_id '
                                 'must be specified and the boot volume of the '
                                 'AWS instance will be copied.', None),
+                ('--volume_type', 'The volume type for the volume copy. '
+                                  'Can be standard, io1, gp2, sc1, st1. The '
+                                  'default behavior is to use the same volume '
+                                  'type as the source volume.', None),
                 ('--src_profile', 'The name of the profile for the source '
                                   'account, as defined in the AWS credentials '
                                   'file.', None),
@@ -149,6 +153,9 @@ def Main() -> None:
                  ''),
                 ('--boot_volume_size', 'Size of instance boot volume in GB.',
                  '50'),
+                ('--boot_volume_type', 'The boot volume type for the VM. '
+                                       'Can be standard, io1, gp2, sc1, st1. '
+                                       'Default is gp2', 'gp2'),
                 ('--cpu_cores', 'Instance CPU core count.', '4'),
                 ('--ami', 'AMI ID to use as base image. Will search '
                           'Ubuntu 18.04 LTS server x86_64 for chosen region '


### PR DESCRIPTION
This PR:

- Adds `--volume_type` CLI argument for AWS, allowing users to select the volume type they want to have for their volume copies

- Adds  `--boot_volume_type` CLI argument for AWS, allowing users to select the volume type they want to have for their analysis VM

The default behavior for volume copies is to use the same volume type as the source volume.

Closes #220 

Signed-off-by: Theo Giovanna <gtheo@google.com>