### PR TITLE
Refactor Azure module

### DIFF
--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -14,26 +14,17 @@
 # limitations under the License.
 """Represents an Azure account."""
 
-import base64
-import hashlib
-from time import sleep
-from typing import Optional, Dict, Tuple, List, Any
+from typing import Optional
 
-# Pylint complains about the import but the library imports just fine,
-# so we can ignore the warning.
-# pylint: disable=import-error
-import sshpubkeys
-from azure.core import exceptions
-from azure.mgmt import compute as azure_compute
-from azure.mgmt import resource, storage, network
-from azure.mgmt.compute.v2020_05_01 import models
-from azure.storage import blob
-from msrestazure import azure_exceptions
-# pylint: enable=import-error
-
-from libcloudforensics.providers.azure.internal import compute, common
+# pylint: disable=line-too-long
+from libcloudforensics.providers.azure.internal import common
+from libcloudforensics.providers.azure.internal import compute as compute_module
+from libcloudforensics.providers.azure.internal import monitoring as monitoring_module
+from libcloudforensics.providers.azure.internal import network as network_module
+from libcloudforensics.providers.azure.internal import resource as resource_module
+from libcloudforensics.providers.azure.internal import storage as storage_module
 from libcloudforensics import logging_utils
-from libcloudforensics.scripts import utils
+# pylint: enable=line-too-long
 
 logging_utils.SetUpLogger(__name__)
 logger = logging_utils.GetLogger(__name__)
@@ -45,7 +36,9 @@ class AZAccount:
   Attributes:
     subscription_id (str): The Azure subscription ID to use.
     credentials (ServicePrincipalCredentials): An Azure credentials object.
-    compute_client (ComputeManagementClient): An Azure compute client object.
+    default_region (str): The default region to create new resources in.
+    default_resource_group_name (str): The default resource group in which to
+          create new resources in.
   """
 
   def __init__(self,
@@ -68,729 +61,70 @@ class AZAccount:
     """
     self.subscription_id, self.credentials = common.GetCredentials(profile_name)
     self.default_region = default_region
-    self.compute_client = azure_compute.ComputeManagementClient(
-        self.credentials, self.subscription_id)
-    self.storage_client = storage.StorageManagementClient(
-        self.credentials, self.subscription_id)
-    self.resource_client = resource.ResourceManagementClient(
-        self.credentials, self.subscription_id)
-    self.network_client = network.NetworkManagementClient(
-        self.credentials, self.subscription_id)
-    self.default_resource_group_name = self._GetOrCreateResourceGroup(
+    self._compute = None  # type: Optional[compute_module.AZCompute]
+    self._monitoring = None  # type: Optional[monitoring_module.AZMonitoring]
+    self._network = None  # type: Optional[network_module.AZNetwork]
+    self._resource = None  # type: Optional[resource_module.AZResource]
+    self._storage = None  # type: Optional[storage_module.AZStorage]
+    self.default_resource_group_name = self.resource.GetOrCreateResourceGroup(
         default_resource_group_name)
 
-  def ListSubscriptionIDs(self) -> List[str]:
-    """List subscription ids from an Azure account.
+  @property
+  def compute(self) -> compute_module.AZCompute:
+    """Get an Azure compute object for the account.
 
     Returns:
-      List[str]: A list of all subscription IDs from the Azure account.
+      AZCompute: An Azure compute object.
     """
-    subscription_client = resource.SubscriptionClient(self.credentials)
-    subscription_ids = subscription_client.subscriptions.list()
-    return [sub.subscription_id for sub in subscription_ids]
+    if self._compute:
+      return self._compute
+    self._compute = compute_module.AZCompute(self)
+    return self._compute
 
-  def ListInstances(self,
-                    resource_group_name: Optional[str] = None
-                    ) -> Dict[str, compute.AZVirtualMachine]:
-    """List instances in an Azure subscription / resource group.
-
-    Args:
-      resource_group_name (str): Optional. The resource group name to list
-          instances from. If none specified, then all instances in the Azure
-          subscription will be listed.
+  @property
+  def monitoring(self) -> monitoring_module.AZMonitoring:
+    """Get an Azure monitoring object for the account.
 
     Returns:
-      Dict[str, AZVirtualMachine]: Dictionary mapping instance names (str) to
-          their respective AZVirtualMachine object.
+      AZMonitoring: An Azure monitoring object.
     """
-    instances = {}  # type: Dict[str, compute.AZVirtualMachine]
-    az_vm_client = self.compute_client.virtual_machines
-    if not resource_group_name:
-      responses = common.ExecuteRequest(az_vm_client, 'list_all')
-    else:
-      responses = common.ExecuteRequest(
-          az_vm_client,
-          'list',
-          {'resource_group_name': resource_group_name})
-    for response in responses:
-      for instance in response:
-        instances[instance.name] = compute.AZVirtualMachine(
-            self,
-            instance.id,
-            instance.name,
-            instance.location,
-            zones=instance.zones)
-    return instances
+    if self._monitoring:
+      return self._monitoring
+    self._monitoring = monitoring_module.AZMonitoring(self)
+    return self._monitoring
 
-  def ListDisks(
-      self,
-      resource_group_name: Optional[str] = None) -> Dict[str, compute.AZDisk]:
-    """List disks in an Azure subscription / resource group.
-
-    Args:
-      resource_group_name (str): Optional. The resource group name to list
-          disks from. If none specified, then all disks in the AZ
-          subscription will be listed.
+  @property
+  def network(self) -> network_module.AZNetwork:
+    """Get an Azure network object for the account.
 
     Returns:
-      Dict[str, AZDisk]: Dictionary mapping disk names (str) to their
-          respective AZDisk object.
+      AZNetwork: An Azure network object.
     """
-    disks = {}  # type: Dict[str, compute.AZDisk]
-    az_disk_client = self.compute_client.disks
-    if not resource_group_name:
-      responses = common.ExecuteRequest(az_disk_client, 'list')
-    else:
-      responses = common.ExecuteRequest(
-          az_disk_client,
-          'list_by_resource_group',
-          {'resource_group_name': resource_group_name})
-    for response in responses:
-      for disk in response:
-        disks[disk.name] = compute.AZDisk(self,
-                                          disk.id,
-                                          disk.name,
-                                          disk.location,
-                                          zones=disk.zones)
-    return disks
+    if self._network:
+      return self._network
+    self._network = network_module.AZNetwork(self)
+    return self._network
 
-  def GetInstance(
-      self,
-      instance_name: str,
-      resource_group_name: Optional[str] = None) -> compute.AZVirtualMachine:
-    """Get instance from AZ subscription / resource group.
-
-    Args:
-      instance_name (str): The instance name.
-      resource_group_name (str): Optional. The resource group name to look
-          the instance in. If none specified, then the instance will be fetched
-          from the AZ subscription.
+  @property
+  def resource(self) -> resource_module.AZResource:
+    """Get an Azure resource object for the account.
 
     Returns:
-      AZVirtualMachine: An Azure virtual machine object.
-
-    Raises:
-      RuntimeError: If the instance was not found in the subscription / resource
-          group.
+      AZResource: An Azure resource object.
     """
-    instances = self.ListInstances(resource_group_name=resource_group_name)
-    if instance_name not in instances:
-      error_msg = 'Instance {0:s} was not found in subscription {1:s}'.format(
-          instance_name, self.subscription_id)
-      raise RuntimeError(error_msg)
-    return instances[instance_name]
+    if self._resource:
+      return self._resource
+    self._resource = resource_module.AZResource(self)
+    return self._resource
 
-  def GetDisk(
-      self,
-      disk_name: str,
-      resource_group_name: Optional[str] = None) -> compute.AZDisk:
-    """Get disk from AZ subscription / resource group.
-
-    Args:
-      disk_name (str): The disk name.
-      resource_group_name (str): Optional. The resource group name to look
-          the disk in. If none specified, then the disk will be fetched from
-          the AZ subscription.
+  @property
+  def storage(self) -> storage_module.AZStorage:
+    """Get an Azure storage object for the account.
 
     Returns:
-      AZDisk: An Azure Compute Disk object.
-
-    Raises:
-      RuntimeError: If the disk was not found in the subscription / resource
-          group.
+      AZStorage: An Azure storage object.
     """
-    disks = self.ListDisks(resource_group_name=resource_group_name)
-    if disk_name not in disks:
-      error_msg = 'Disk {0:s} was not found in subscription {1:s}'.format(
-          disk_name, self.subscription_id)
-      raise RuntimeError(error_msg)
-    return disks[disk_name]
-
-  def CreateDiskFromSnapshot(
-      self,
-      snapshot: compute.AZSnapshot,
-      region: Optional[str] = None,
-      disk_name: Optional[str] = None,
-      disk_name_prefix: Optional[str] = None,
-      disk_type: str = 'Standard_LRS') -> compute.AZDisk:
-    """Create a new disk based on a Snapshot.
-
-    Args:
-      snapshot (AZSnapshot): Snapshot to use.
-      region (str): Optional. The region in which to create the disk. If not
-          provided, the disk will be created in the default_region associated to
-          the AZAccount object.
-      disk_name (str): Optional. String to use as new disk name.
-      disk_name_prefix (str): Optional. String to prefix the disk name with.
-      disk_type (str): Optional. The sku name for the disk to create. Can be
-          Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
-          default value is Standard_LRS.
-
-    Returns:
-      AZDisk: Azure Compute Disk.
-
-    Raises:
-      RuntimeError: If the disk could not be created.
-    """
-
-    if not disk_name:
-      disk_name = common.GenerateDiskName(snapshot,
-                                          disk_name_prefix=disk_name_prefix)
-
-    if not region:
-      region = self.default_region
-
-    creation_data = {
-        'location': region,
-        'creation_data': {
-            'sourceResourceId': snapshot.resource_id,
-            'create_option': models.DiskCreateOption.copy
-        },
-        'sku': {'name': disk_type}
-    }
-
-    try:
-      logger.info('Creating disk: {0:s}'.format(disk_name))
-      request = self.compute_client.disks.create_or_update(
-          self.default_resource_group_name,
-          disk_name,
-          creation_data)
-      while not request.done():
-        sleep(5)  # Wait 5 seconds before checking disk status again
-      disk = request.result()
-      logger.info('Disk {0:s} successfully created'.format(disk_name))
-    except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not create disk from snapshot {0:s}: {1:s}'
-                         .format(snapshot.resource_id, str(exception)))
-
-    return compute.AZDisk(self,
-                          disk.id,
-                          disk.name,
-                          disk.location,
-                          disk.zones)
-
-  def CreateDiskFromSnapshotURI(
-      self,
-      snapshot: compute.AZSnapshot,
-      snapshot_uri: str,
-      region: Optional[str] = None,
-      disk_name: Optional[str] = None,
-      disk_name_prefix: Optional[str] = None,
-      disk_type: str = 'Standard_LRS') -> compute.AZDisk:
-    """Create a new disk based on a SAS snapshot URI.
-
-    This is useful if e.g. one wants to make a copy of a disk in a separate
-    Azure account. This method will create a temporary Azure Storage account
-    within the destination account, import the snapshot from a downloadable
-    link (the source account needs to share the snapshot through a SAS link)
-    and then create a disk from the VHD file saved in storage. The Azure
-    storage account is then deleted.
-
-    Args:
-      snapshot (AZSnapshot): Source snapshot to use.
-      snapshot_uri (str): The URI of the snapshot to copy.
-      region (str): Optional. The region in which to create the disk. If not
-          provided, the disk will be created in the default_region associated to
-          the AZAccount object.
-      disk_name (str): Optional. String to use as new disk name.
-      disk_name_prefix (str): Optional. String to prefix the disk name with.
-      disk_type (str): Optional. The sku name for the disk to create. Can be
-          Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS.
-          Default is Standard_LRS.
-
-    Returns:
-      AZDisk: Azure Compute Disk.
-
-    Raises:
-      RuntimeError: If the disk could not be created.
-    """
-
-    if not region:
-      region = self.default_region
-
-    # Create a temporary Azure account storage to import the snapshot
-    storage_account_name = hashlib.sha1(
-        snapshot.resource_id.encode('utf-8')).hexdigest()[:23]
-    storage_account_url = 'https://{0:s}.blob.core.windows.net'.format(
-        storage_account_name)
-    storage_account_id, storage_account_access_key = self._CreateStorageAccount(
-        storage_account_name, region=region)
-    blob_service_client = blob.BlobServiceClient(
-        account_url=storage_account_url, credential=storage_account_access_key)
-
-    # Create a container within the Storage to receive the imported snapshot
-    container_name = storage_account_name + '-container'
-    snapshot_vhd_name = snapshot.name + '.vhd'
-    container_client = blob_service_client.get_container_client(container_name)
-    try:
-      logger.info('Creating blob container {0:s}'.format(container_name))
-      container_client.create_container()
-      logger.info('Blob container {0:s} successfully created'.format(
-          container_name))
-    except exceptions.ResourceExistsError:
-      # The container already exists, so we can re-use it
-      logger.warning('Reusing existing container: {0:s}'.format(container_name))
-
-    # Download the snapshot from the URI to the storage
-    copied_blob = blob_service_client.get_blob_client(
-        container_name, snapshot_vhd_name)
-    logger.info('Importing snapshot to container from URI {0:s}. '
-                'Depending on the size of the snapshot, this process is going '
-                'to take a while.'.format(snapshot_uri))
-    copied_blob.start_copy_from_url(snapshot_uri)
-    copy_status = copied_blob.get_blob_properties().copy.status
-    while copy_status != 'success':
-      sleep(5)  # Wait for the vhd to be imported in the Azure storage container
-      copy_status = copied_blob.get_blob_properties().copy.status
-      if copy_status in ('aborted', 'failed'):
-        raise RuntimeError('Could not import the snapshot from URI '
-                           '{0:s}'.format(snapshot_uri))
-      logger.debug('Importing snapshot from URI {0:s}'.format(snapshot_uri))
-    logger.info('Snapshot successfully imported from URI {0:s}'.format(
-        snapshot_uri))
-
-    if not disk_name:
-      disk_name = common.GenerateDiskName(snapshot,
-                                          disk_name_prefix=disk_name_prefix)
-
-    # Create a new disk from the imported snapshot
-    creation_data = {
-        'location': region,
-        'creation_data': {
-            'source_uri': copied_blob.url,
-            'storage_account_id': storage_account_id,
-            'create_option': models.DiskCreateOption.import_enum
-        },
-        'sku': {'name': disk_type}
-    }
-
-    try:
-      logger.info('Creating disk: {0:s}'.format(disk_name))
-      request = self.compute_client.disks.create_or_update(
-          self.default_resource_group_name,
-          disk_name,
-          creation_data)
-      while not request.done():
-        sleep(5)  # Wait 5 seconds before checking disk status again
-      disk = request.result()
-      logger.info('Disk {0:s} successfully created'.format(disk_name))
-    except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not create disk from URI {0:s}: {1:s}'
-                         .format(snapshot_uri, str(exception)))
-
-    # Cleanup the temporary account storage
-    self._DeleteStorageAccount(storage_account_name)
-
-    return compute.AZDisk(self,
-                          disk.id,
-                          disk.name,
-                          disk.location,
-                          disk.zones)
-
-  def GetOrCreateAnalysisVm(
-      self,
-      vm_name: str,
-      boot_disk_size: int,
-      cpu_cores: int,
-      memory_in_mb: int,
-      ssh_public_key: str,
-      region: Optional[str] = None,
-      packages: Optional[List[str]] = None,
-      tags: Optional[Dict[str, str]] = None
-  ) -> Tuple[compute.AZVirtualMachine, bool]:
-    """Get or create a new virtual machine for analysis purposes.
-
-    Args:
-      vm_name (str): The instance name tag of the virtual machine.
-      boot_disk_size (int): The size of the analysis VM boot volume (in GB).
-      cpu_cores (int): Number of CPU cores for the analysis VM.
-      memory_in_mb (int): The memory size (in MB) for the analysis VM.
-      ssh_public_key (str): A SSH public key data to associate with the
-          VM. This must be provided as otherwise the VM will not be
-          accessible.
-      region (str): Optional. The region in which to create the vm. If not
-          provided, the vm will be created in the default_region
-          associated to the AZAccount object.
-      packages (List[str]): Optional. List of packages to install in the VM.
-      tags (Dict[str, str]): Optional. A dictionary of tags to add to the
-          instance, for example {'TicketID': 'xxx'}. An entry for the
-          instance name is added by default.
-
-    Returns:
-      Tuple[AWSInstance, bool]: A tuple with an AZVirtualMachine object
-          and a boolean indicating if the virtual machine was created
-          (True) or reused (False).
-
-    Raises:
-      RuntimeError: If the virtual machine cannot be found or created.
-    """
-
-    # Re-use instance if it already exists, or create a new one.
-    try:
-      instance = self.GetInstance(vm_name)
-      if instance:
-        created = False
-        return instance, created
-    except RuntimeError:
-      pass
-
-    # Validate SSH public key format
-    try:
-      sshpubkeys.SSHKey(ssh_public_key, strict=True).parse()
-    except sshpubkeys.InvalidKeyError as exception:
-      raise RuntimeError('The provided public SSH key is invalid: '
-                         '{0:s}'.format(str(exception)))
-
-    instance_type = self._GetInstanceType(cpu_cores, memory_in_mb)
-    startup_script = utils.ReadStartupScript()
-    if packages:
-      startup_script = startup_script.replace('${packages[@]}', ' '.join(
-          packages))
-
-    if not region:
-      region = self.default_region
-
-    creation_data = {
-        'location': region,
-        'properties': {
-            'hardwareProfile': {'vmSize': instance_type},
-            'storageProfile': {
-                'imageReference': {
-                    'sku': '18.04-LTS',
-                    'publisher': 'Canonical',
-                    'version': 'latest',
-                    'offer': 'UbuntuServer'}
-            },
-            'osDisk': {
-                'caching': 'ReadWrite',
-                'managedDisk': {'storageAccountType': 'Standard_LRS'},
-                'name': 'os-disk-{0:s}'.format(vm_name),
-                'diskSizeGb': boot_disk_size,
-                'createOption': models.DiskCreateOption.from_image
-            },
-            'osProfile': {
-                'adminUsername': 'AzureUser',
-                'computerName': vm_name,
-                # Azure requires the startup script to be sent as a b64 string
-                'customData': base64.b64encode(
-                    str.encode(startup_script)).decode('utf-8'),
-                'linuxConfiguration': {
-                    'ssh': {
-                        'publicKeys': [{
-                            'path': '/home/AzureUser/.ssh/authorized_keys',
-                            'keyData': ssh_public_key}]
-                    }
-                }
-            },
-            'networkProfile': {
-                'networkInterfaces': [
-                    {'id': self._CreateNetworkInterfaceForVM(vm_name, region)}
-                ]
-            }
-        }
-    }  # type: Dict[str, Any]
-
-    if tags:
-      creation_data['tags'] = tags
-
-    try:
-      request = self.compute_client.virtual_machines.create_or_update(
-          self.default_resource_group_name,
-          vm_name,
-          creation_data
-      )
-      while not request.done():
-        sleep(5)  # Wait 5 seconds before checking disk status again
-      vm = request.result()
-    except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not create instance {0:s}: {1:s}'.format(
-          vm_name, str(exception)))
-
-    instance = compute.AZVirtualMachine(self,
-                                        vm.id,
-                                        vm.name,
-                                        vm.location,
-                                        zones=vm.zones)
-    created = True
-    return instance, created
-
-  def ListInstanceTypes(self,
-                        region: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Returns a list of available VM sizes for a given region.
-
-    Args:
-      region (str): Optional. The region in which to look the instance types.
-          By default, look in the default_region associated to the AZAccount
-          object.
-
-    Returns:
-      List[Dict[str, str]]: A list of available vm size. Each size is a
-          dictionary containing the name of the configuration, the number of
-          CPU cores, and the amount of available memory (in MB).
-          E.g.: {'Name': 'Standard_B1ls', 'CPU': 1, 'Memory': 512}
-    """
-    if not region:
-      region = self.default_region
-    available_vms = self.compute_client.virtual_machine_sizes.list(region)
-    vm_sizes = []
-    for vm in available_vms:
-      vm_sizes.append({
-          'Name': vm.name,
-          'CPU': vm.number_of_cores,
-          'Memory': vm.memory_in_mb
-      })
-    return vm_sizes
-
-  def _GetInstanceType(self, cpu_cores: int, memory_in_mb: int) -> str:
-    """Returns an instance type for the given number of CPU cores / memory.
-
-    Args:
-      cpu_cores (int): The number of CPU cores.
-      memory_in_mb (int): The amount of memory (in MB).
-
-    Returns:
-      str: The instance type for the given configuration.
-
-    Raises:
-      ValueError: If no instance type matches the requested configuration.
-    """
-    vm_sizes = self.ListInstanceTypes()
-    for size in vm_sizes:
-      if size['CPU'] == cpu_cores and size['Memory'] == memory_in_mb:
-        instance_type = size['Name']  # type: str
-        return instance_type
-    raise ValueError(
-        'No instance type found for the requested configuration: {0:d} CPU '
-        'cores, {1:d} MB memory.'.format(cpu_cores, memory_in_mb))
-
-  def _CreateNetworkInterfaceForVM(self,
-                                   vm_name: str,
-                                   region: Optional[str] = None) -> str:
-    """Create a network interface and returns its ID.
-    This is necessary when creating a VM from the SDK.
-    See https://docs.microsoft.com/en-us/azure/virtual-machines/windows/python
-
-    Args:
-      vm_name (str): The name of the VM to create the network interface for.
-      region (str): Optional. The region in which to create the network
-          interface. Default uses default_region of the AZAccount object.
-
-    Returns:
-      str: The id of the created network interface.
-
-    Raises:
-      ValueError: if vm_name is not provided.
-      RuntimeError: If no network interface could be created.
-    """
-    if not vm_name:
-      raise ValueError(
-          'vm_name must be specified. Provided: {0!s}'.format(vm_name))
-
-    if not region:
-      region = self.default_region
-
-    network_interface_name = '{0:s}-nic'.format(vm_name)
-    ip_config_name = '{0:s}-ipconfig'.format(vm_name)
-
-    # Check if the network interface already exists, and returns its ID if so.
-    try:
-      nic = self.network_client.network_interfaces.get(
-          self.default_resource_group_name, network_interface_name)
-      nic_id = nic.id  # type: str
-      return nic_id
-    except azure_exceptions.CloudError:
-      # NIC doesn't exist, ignore the error and create it
-      pass
-
-    # pylint: disable=unbalanced-tuple-unpacking
-    public_ip, _, subnet = self._CreateNetworkInterfaceElements(
-        vm_name, region=region)
-    # pylint: enable=unbalanced-tuple-unpacking
-
-    creation_data = {
-        'location': region,
-        'ip_configurations': [{
-            'name': ip_config_name,
-            'public_ip_address': public_ip,
-            'subnet': {
-                'id': subnet.id
-            }
-        }]
-    }
-
-    try:
-      request = self.network_client.network_interfaces.create_or_update(
-          self.default_resource_group_name,
-          network_interface_name,
-          creation_data)
-      request.wait()
-    except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not create network interface: {0:s}'.format(
-          str(exception)))
-
-    network_interface_id = request.result().id  # type: str
-    return network_interface_id
-
-  def _CreateNetworkInterfaceElements(
-      self,
-      vm_name: str,
-      region: Optional[str] = None) -> Tuple[Any, ...]:
-    """Creates required elements for creating a network interface.
-
-    Args:
-      vm_name (str): The name of the VM to create the network interface
-          elements for.
-      region (str): Optional. The region in which to create the elements.
-          Default uses default_region of the AZAccount object.
-
-    Returns:
-      Tuple[Any, Any, Any]: A tuple containing a public IP address object,
-          a virtual network object and a subnet object.
-
-    Raises:
-      RuntimeError: If the elements could not be created.
-    """
-
-    if not region:
-      region = self.default_region
-
-    public_ip_name = '{0:s}-public-ip'.format(vm_name)
-    vnet_name = '{0:s}-vnet'.format(vm_name)
-    subnet_name = '{0:s}-subnet'.format(vm_name)
-
-    client_to_creation_data = {
-        self.network_client.public_ip_addresses: {
-            'resource_group_name': self.default_resource_group_name,
-            'public_ip_address_name': public_ip_name,
-            'parameters': {
-                'location': region,
-                'public_ip_allocation_method': 'Dynamic'
-            }
-        },
-        self.network_client.virtual_networks: {
-            'resource_group_name': self.default_resource_group_name,
-            'virtual_network_name': vnet_name,
-            'parameters': {
-                'location': region,
-                'address_space': {'address_prefixes': ['10.0.0.0/16']}
-            }
-        },
-        self.network_client.subnets: {
-            'resource_group_name': self.default_resource_group_name,
-            'virtual_network_name': vnet_name,
-            'subnet_name': subnet_name,
-            'subnet_parameters': {
-                'address_prefix': '10.0.0.0/24'
-            }
-        }
-    }  # type: Dict[str, Any]
-
-    result = []
-    try:
-      for client in client_to_creation_data:
-        request = common.ExecuteRequest(
-            client, 'create_or_update', client_to_creation_data[client])[0]
-        request.wait()
-        result.append(request.result())
-    except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not create network interface elements: '
-                         '{0:s}'.format(str(exception)))
-    return tuple(result)
-
-  def _CreateStorageAccount(self,
-                            storage_account_name: str,
-                            region: Optional[str] = None) -> Tuple[str, str]:
-    """Create a storage account and returns its ID and access key.
-
-    Args:
-      storage_account_name (str): The name for the storage account.
-      region (str): Optional. The region in which to create the storage
-          account. If not provided, it will be created in the default_region
-          associated to the AZAccount object.
-
-    Returns:
-      Tuple[str, str]: The storage account ID and its access key.
-
-    Raises:
-      ValueError: If the storage account name is invalid.
-    """
-
-    if not common.REGEX_ACCOUNT_STORAGE_NAME.match(storage_account_name):
-      raise ValueError(
-          'Storage account name {0:s} does not comply with {1:s}'.format(
-              storage_account_name, common.REGEX_ACCOUNT_STORAGE_NAME.pattern))
-
-    if not region:
-      region = self.default_region
-
-    # https://docs.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
-    creation_data = {
-        'location': region,
-        'sku': {
-            'name': 'Standard_RAGRS'
-        },
-        'kind': 'Storage'
-    }
-
-    # pylint: disable=line-too-long
-    # https://docs.microsoft.com/en-us/samples/azure-samples/storage-python-manage/storage-python-manage/
-    # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python
-    # pylint: enable=line-too-long
-    logger.info('Creating storage account: {0:s}'.format(storage_account_name))
-    request = self.storage_client.storage_accounts.create(
-        self.default_resource_group_name,
-        storage_account_name,
-        creation_data
-    )
-    logger.info('Storage account {0:s} successfully created'.format(
-        storage_account_name))
-    storage_account = request.result()
-    storage_account_keys = self.storage_client.storage_accounts.list_keys(
-        self.default_resource_group_name, storage_account_name)
-    storage_account_keys = {key.key_name: key.value
-                            for key in storage_account_keys.keys}
-    storage_account_id = storage_account.id  # type: str
-    storage_account_key = storage_account_keys['key1']  # type: str
-    return storage_account_id, storage_account_key
-
-  def _DeleteStorageAccount(self, storage_account_name: str) -> None:
-    """Delete an account storage.
-
-    Raises:
-      RuntimeError: if the storage account could not be deleted.
-    """
-    try:
-      logger.info('Deleting storage account: {0:s}'.format(
-          storage_account_name))
-      self.storage_client.storage_accounts.delete(
-          self.default_resource_group_name, storage_account_name)
-      logger.info('Storage account {0:s} successfully deleted'.format(
-          storage_account_name))
-    except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not delete account storage {0:s}: {1:s}'
-                         .format(storage_account_name, str(exception)))
-
-  def _GetOrCreateResourceGroup(self, resource_group_name: str) -> str:
-    """Check if a resource group exists, and create it otherwise.
-
-    Args:
-      resource_group_name (str); The name of the resource group to check
-          existence for. If it does not exist, create it.
-
-    Returns:
-      str: The resource group name.
-    """
-    try:
-      self.resource_client.resource_groups.get(resource_group_name)
-    except azure_exceptions.CloudError:
-      # Group doesn't exist, creating it
-      logger.info('Resource group {0:s} not found, creating it.'.format(
-          resource_group_name))
-      creation_data = {
-          'location': self.default_region
-      }
-      self.resource_client.resource_groups.create_or_update(
-          resource_group_name, creation_data)
-      logger.info('Resource group {0:s} successfully created.'.format(
-          resource_group_name))
-    return resource_group_name
+    if self._storage:
+      return self._storage
+    self._storage = storage_module.AZStorage(self)
+    return self._storage

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 REGEX_DISK_NAME = re.compile('^[\\w]{1,80}$')
 REGEX_SNAPSHOT_NAME = re.compile('^(?=.{1,80}$)[a-zA-Z0-9]([\\w,-]*[\\w])?$')
 REGEX_ACCOUNT_STORAGE_NAME = re.compile('^[a-z0-9]{1,24}$')
+REGEX_COMPUTE_RESOURCE_ID = re.compile(
+    '/subscriptions/.+/resourceGroups/.+/providers/Microsoft.Compute/.+/.+')
 
 DEFAULT_DISK_COPY_PREFIX = 'evidence'
 

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -40,6 +40,8 @@ REGEX_COMPUTE_RESOURCE_ID = re.compile(
 
 DEFAULT_DISK_COPY_PREFIX = 'evidence'
 
+UBUNTU_1804_SKU = '18.04-LTS'
+
 
 def GetCredentials(profile_name: Optional[str] = None
                    ) -> Tuple[str, ServicePrincipalCredentials]:

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -165,7 +165,7 @@ def ExecuteRequest(
       return responses
 
 
-def GenerateDiskName(snapshot: 'compute.AZSnapshot',
+def GenerateDiskName(snapshot: 'compute.AZComputeSnapshot',
                      disk_name_prefix: Optional[str] = None) -> str:
   """Generate a new disk name for the disk to be created from the Snapshot.
 
@@ -176,7 +176,7 @@ def GenerateDiskName(snapshot: 'compute.AZSnapshot',
   characters and underscores.
 
   Args:
-    snapshot (AZSnapshot): A disk's Snapshot.
+    snapshot (AZComputeSnapshot): A disk's Snapshot.
     disk_name_prefix (str): Optional. A prefix for the disk name.
 
   Returns:

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -432,7 +432,7 @@ class AZCompute:
             'hardwareProfile': {'vmSize': instance_type},
             'storageProfile': {
                 'imageReference': {
-                    'sku': '18.04-LTS',
+                    'sku': common.UBUNTU_1804_SKU,
                     'publisher': 'Canonical',
                     'version': 'latest',
                     'offer': 'UbuntuServer'}

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -12,20 +12,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Azure Compute Resources."""
+"""Azure Compute functionality."""
 
+import base64
+import hashlib
 from time import sleep
-from typing import Optional, List, Dict, TYPE_CHECKING
+from typing import Optional, List, Dict, TYPE_CHECKING, Tuple, Any
 
 # Pylint complains about the import but the library imports just fine,
 # so we can ignore the warning.
 # pylint: disable=import-error
-from azure.mgmt.compute.v2020_05_01 import models
+import sshpubkeys
 from msrestazure import azure_exceptions
+from azure.storage import blob
+from azure.core import exceptions
+from azure.mgmt import compute as compute_sdk
+from azure.mgmt.compute.v2020_05_01 import models
 # pylint: enable=import-error
 
 from libcloudforensics import logging_utils
-from libcloudforensics.providers.azure.internal import common
+from libcloudforensics.providers.azure.internal import common, compute_base_resource  # pylint: disable=line-too-long, ungrouped-imports
+
+from libcloudforensics.scripts import utils
 
 if TYPE_CHECKING:
   # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
@@ -36,47 +44,508 @@ logging_utils.SetUpLogger(__name__)
 logger = logging_utils.GetLogger(__name__)
 
 
-class AZComputeResource:
-  """Class that represent an Azure compute resource
+class AZCompute:
+  """Class representing all Azure Compute objects in an account.
 
   Attributes:
-    az_account (AZAccount): An Azure account object.
-    resource_group_name (str): The Azure resource group name for the resource.
-    resource_id (str): The Azure resource ID.
-    name (str): The resource's name.
-    region (str): The region in which the resource is located.
-    zones (List[str]): Optional. Availability zones within the region where
-        the resource is located.
+    az_account: An Azure account object.
+    compute_client (ComputeManagementClient): An Azure compute client object.
   """
-
-  def __init__(self,
-               az_account: 'account.AZAccount',
-               resource_id: str,
-               name: str,
-               region: str,
-               zones: Optional[List[str]] = None) -> None:
-    """Initialize the AZComputeResource class.
+  def __init__(self, az_account: 'account.AZAccount') -> None:
+    """Initialize the AZCompute class.
 
     Args:
       az_account (AZAccount): An Azure account object.
-      resource_id (str): The Azure resource ID.
-      name (str): The resource's name.
-      region (str): The region in which the resource is located.
-      zones (List[str]): Optional. Availability zones within the region where
-          the resource is located.
+    """
+    self.az_account = az_account
+    self.compute_client = compute_sdk.ComputeManagementClient(
+        self.az_account.credentials,
+        self.az_account.subscription_id
+    )  # type: compute_sdk.ComputeManagementClient
+
+  def ListInstances(self,
+                    resource_group_name: Optional[str] = None
+                    ) -> Dict[str, 'AZComputeVirtualMachine']:
+    """List instances in an Azure subscription / resource group.
+
+    Args:
+      resource_group_name (str): Optional. The resource group name to list
+          instances from. If none specified, then all instances in the Azure
+          subscription will be listed.
+
+    Returns:
+      Dict[str, AZComputeVirtualMachine]: Dictionary mapping instance names
+          (str) to their respective AZComputeVirtualMachine object.
+    """
+    instances = {}  # type: Dict[str, AZComputeVirtualMachine]
+    az_vm_client = self.compute_client.virtual_machines
+    if not resource_group_name:
+      responses = common.ExecuteRequest(az_vm_client, 'list_all')
+    else:
+      responses = common.ExecuteRequest(
+          az_vm_client,
+          'list',
+          {'resource_group_name': resource_group_name})
+    for response in responses:
+      for instance in response:
+        instances[instance.name] = AZComputeVirtualMachine(
+            self.az_account,
+            instance.id,
+            instance.name,
+            instance.location,
+            zones=instance.zones)
+    return instances
+
+  def ListDisks(
+      self,
+      resource_group_name: Optional[str] = None) -> Dict[str, 'AZComputeDisk']:
+    """List disks in an Azure subscription / resource group.
+
+    Args:
+      resource_group_name (str): Optional. The resource group name to list
+          disks from. If none specified, then all disks in the AZ
+          subscription will be listed.
+
+    Returns:
+      Dict[str, AZComputeDisk]: Dictionary mapping disk names (str) to their
+          respective AZComputeDisk object.
+    """
+    disks = {}  # type: Dict[str, AZComputeDisk]
+    az_disk_client = self.compute_client.disks
+    if not resource_group_name:
+      responses = common.ExecuteRequest(az_disk_client, 'list')
+    else:
+      responses = common.ExecuteRequest(
+          az_disk_client,
+          'list_by_resource_group',
+          {'resource_group_name': resource_group_name})
+    for response in responses:
+      for disk in response:
+        disks[disk.name] = AZComputeDisk(self.az_account,
+                                         disk.id,
+                                         disk.name,
+                                         disk.location,
+                                         zones=disk.zones)
+    return disks
+
+  def GetInstance(
+      self,
+      instance_name: str,
+      resource_group_name: Optional[str] = None) -> 'AZComputeVirtualMachine':
+    """Get instance from AZ subscription / resource group.
+
+    Args:
+      instance_name (str): The instance name.
+      resource_group_name (str): Optional. The resource group name to look
+          the instance in. If none specified, then the instance will be fetched
+          from the AZ subscription.
+
+    Returns:
+      AZComputeVirtualMachine: An Azure virtual machine object.
+
+    Raises:
+      RuntimeError: If the instance was not found in the subscription / resource
+          group.
+    """
+    instances = self.ListInstances(resource_group_name=resource_group_name)
+    if instance_name not in instances:
+      error_msg = 'Instance {0:s} was not found in subscription {1:s}'.format(
+          instance_name, self.az_account.subscription_id)
+      raise RuntimeError(error_msg)
+    return instances[instance_name]
+
+  def GetDisk(
+      self,
+      disk_name: str,
+      resource_group_name: Optional[str] = None) -> 'AZComputeDisk':
+    """Get disk from AZ subscription / resource group.
+
+    Args:
+      disk_name (str): The disk name.
+      resource_group_name (str): Optional. The resource group name to look
+          the disk in. If none specified, then the disk will be fetched from
+          the AZ subscription.
+
+    Returns:
+      AZComputeDisk: An Azure Compute Disk object.
+
+    Raises:
+      RuntimeError: If the disk was not found in the subscription / resource
+          group.
+    """
+    disks = self.ListDisks(resource_group_name=resource_group_name)
+    if disk_name not in disks:
+      error_msg = 'Disk {0:s} was not found in subscription {1:s}'.format(
+          disk_name, self.az_account.subscription_id)
+      raise RuntimeError(error_msg)
+    return disks[disk_name]
+
+  def CreateDiskFromSnapshot(
+      self,
+      snapshot: 'AZComputeSnapshot',
+      region: Optional[str] = None,
+      disk_name: Optional[str] = None,
+      disk_name_prefix: Optional[str] = None,
+      disk_type: str = 'Standard_LRS') -> 'AZComputeDisk':
+    """Create a new disk based on a Snapshot.
+
+    Args:
+      snapshot (AZComputeSnapshot): Snapshot to use.
+      region (str): Optional. The region in which to create the disk. If not
+          provided, the disk will be created in the default_region associated to
+          the AZAccount object.
+      disk_name (str): Optional. String to use as new disk name.
+      disk_name_prefix (str): Optional. String to prefix the disk name with.
+      disk_type (str): Optional. The sku name for the disk to create. Can be
+          Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS. The
+          default value is Standard_LRS.
+
+    Returns:
+      AZComputeDisk: Azure Compute Disk.
+
+    Raises:
+      RuntimeError: If the disk could not be created.
     """
 
-    self.az_account = az_account
-    # Format of resource_id: /subscriptions/{id}/resourceGroups/{
-    # resource_group_name}/providers/Microsoft.Compute/{resourceType}/{resource}
-    self.resource_group_name = resource_id.split('/')[4]
-    self.resource_id = resource_id
-    self.name = name
-    self.region = region
-    self.zones = zones
+    if not disk_name:
+      disk_name = common.GenerateDiskName(snapshot,
+                                          disk_name_prefix=disk_name_prefix)
+
+    if not region:
+      region = self.az_account.default_region
+
+    creation_data = {
+        'location': region,
+        'creation_data': {
+            'sourceResourceId': snapshot.resource_id,
+            'create_option': models.DiskCreateOption.copy
+        },
+        'sku': {'name': disk_type}
+    }
+
+    try:
+      logger.info('Creating disk: {0:s}'.format(disk_name))
+      request = self.compute_client.disks.create_or_update(
+          self.az_account.default_resource_group_name,
+          disk_name,
+          creation_data)
+      while not request.done():
+        sleep(5)  # Wait 5 seconds before checking disk status again
+      disk = request.result()
+      logger.info('Disk {0:s} successfully created'.format(disk_name))
+    except azure_exceptions.CloudError as exception:
+      raise RuntimeError('Could not create disk from snapshot {0:s}: {1:s}'
+                         .format(snapshot.resource_id, str(exception)))
+
+    return AZComputeDisk(self.az_account,
+                         disk.id,
+                         disk.name,
+                         disk.location,
+                         disk.zones)
+
+  def CreateDiskFromSnapshotURI(
+      self,
+      snapshot: 'AZComputeSnapshot',
+      snapshot_uri: str,
+      region: Optional[str] = None,
+      disk_name: Optional[str] = None,
+      disk_name_prefix: Optional[str] = None,
+      disk_type: str = 'Standard_LRS') -> 'AZComputeDisk':
+    """Create a new disk based on a SAS snapshot URI.
+
+    This is useful if e.g. one wants to make a copy of a disk in a separate
+    Azure account. This method will create a temporary Azure Storage account
+    within the destination account, import the snapshot from a downloadable
+    link (the source account needs to share the snapshot through a SAS link)
+    and then create a disk from the VHD file saved in storage. The Azure
+    storage account is then deleted.
+
+    Args:
+      snapshot (AZComputeSnapshot): Source snapshot to use.
+      snapshot_uri (str): The URI of the snapshot to copy.
+      region (str): Optional. The region in which to create the disk. If not
+          provided, the disk will be created in the default_region associated to
+          the AZAccount object.
+      disk_name (str): Optional. String to use as new disk name.
+      disk_name_prefix (str): Optional. String to prefix the disk name with.
+      disk_type (str): Optional. The sku name for the disk to create. Can be
+          Standard_LRS, Premium_LRS, StandardSSD_LRS, or UltraSSD_LRS.
+          Default is Standard_LRS.
+
+    Returns:
+      AZComputeDisk: Azure Compute Disk.
+
+    Raises:
+      RuntimeError: If the disk could not be created.
+    """
+
+    if not region:
+      region = self.az_account.default_region
+
+    # Create a temporary Azure account storage to import the snapshot
+    storage_account_name = hashlib.sha1(
+        snapshot.resource_id.encode('utf-8')).hexdigest()[:23]
+    storage_account_url = 'https://{0:s}.blob.core.windows.net'.format(
+        storage_account_name)
+    # pylint: disable=line-too-long
+    storage_account_id, storage_account_access_key = self.az_account.storage.CreateStorageAccount(
+        storage_account_name, region=region)
+    # pylint: enable=line-too-long
+    blob_service_client = blob.BlobServiceClient(
+        account_url=storage_account_url, credential=storage_account_access_key)
+
+    # Create a container within the Storage to receive the imported snapshot
+    container_name = storage_account_name + '-container'
+    snapshot_vhd_name = snapshot.name + '.vhd'
+    container_client = blob_service_client.get_container_client(container_name)
+    try:
+      logger.info('Creating blob container {0:s}'.format(container_name))
+      container_client.create_container()
+      logger.info('Blob container {0:s} successfully created'.format(
+          container_name))
+    except exceptions.ResourceExistsError:
+      # The container already exists, so we can re-use it
+      logger.warning('Reusing existing container: {0:s}'.format(container_name))
+
+    # Download the snapshot from the URI to the storage
+    copied_blob = blob_service_client.get_blob_client(
+        container_name, snapshot_vhd_name)
+    logger.info('Importing snapshot to container from URI {0:s}. '
+                'Depending on the size of the snapshot, this process is going '
+                'to take a while.'.format(snapshot_uri))
+    copied_blob.start_copy_from_url(snapshot_uri)
+    copy_status = copied_blob.get_blob_properties().copy.status
+    while copy_status != 'success':
+      sleep(5)  # Wait for the vhd to be imported in the Azure storage container
+      copy_status = copied_blob.get_blob_properties().copy.status
+      if copy_status in ('aborted', 'failed'):
+        raise RuntimeError('Could not import the snapshot from URI '
+                           '{0:s}'.format(snapshot_uri))
+      logger.debug('Importing snapshot from URI {0:s}'.format(snapshot_uri))
+    logger.info('Snapshot successfully imported from URI {0:s}'.format(
+        snapshot_uri))
+
+    if not disk_name:
+      disk_name = common.GenerateDiskName(snapshot,
+                                          disk_name_prefix=disk_name_prefix)
+
+    # Create a new disk from the imported snapshot
+    creation_data = {
+        'location': region,
+        'creation_data': {
+            'source_uri': copied_blob.url,
+            'storage_account_id': storage_account_id,
+            'create_option': models.DiskCreateOption.import_enum
+        },
+        'sku': {'name': disk_type}
+    }
+
+    try:
+      logger.info('Creating disk: {0:s}'.format(disk_name))
+      request = self.compute_client.disks.create_or_update(
+          self.az_account.default_resource_group_name,
+          disk_name,
+          creation_data)
+      while not request.done():
+        sleep(5)  # Wait 5 seconds before checking disk status again
+      disk = request.result()
+      logger.info('Disk {0:s} successfully created'.format(disk_name))
+    except azure_exceptions.CloudError as exception:
+      raise RuntimeError('Could not create disk from URI {0:s}: {1:s}'
+                         .format(snapshot_uri, str(exception)))
+
+    # Cleanup the temporary account storage
+    self.az_account.storage.DeleteStorageAccount(storage_account_name)
+
+    return AZComputeDisk(self.az_account,
+                         disk.id,
+                         disk.name,
+                         disk.location,
+                         disk.zones)
+
+  def GetOrCreateAnalysisVm(
+      self,
+      vm_name: str,
+      boot_disk_size: int,
+      cpu_cores: int,
+      memory_in_mb: int,
+      ssh_public_key: str,
+      region: Optional[str] = None,
+      packages: Optional[List[str]] = None,
+      tags: Optional[Dict[str, str]] = None
+  ) -> Tuple['AZComputeVirtualMachine', bool]:
+    """Get or create a new virtual machine for analysis purposes.
+
+    Args:
+      vm_name (str): The instance name tag of the virtual machine.
+      boot_disk_size (int): The size of the analysis VM boot volume (in GB).
+      cpu_cores (int): Number of CPU cores for the analysis VM.
+      memory_in_mb (int): The memory size (in MB) for the analysis VM.
+      ssh_public_key (str): A SSH public key data to associate with the
+          VM. This must be provided as otherwise the VM will not be
+          accessible.
+      region (str): Optional. The region in which to create the vm. If not
+          provided, the vm will be created in the default_region
+          associated to the AZAccount object.
+      packages (List[str]): Optional. List of packages to install in the VM.
+      tags (Dict[str, str]): Optional. A dictionary of tags to add to the
+          instance, for example {'TicketID': 'xxx'}. An entry for the
+          instance name is added by default.
+
+    Returns:
+      Tuple[AZComputeVirtualMachine, bool]: A tuple with an
+          AZComputeVirtualMachine object and a boolean indicating if the
+          virtual machine was created (True) or reused (False).
+
+    Raises:
+      RuntimeError: If the virtual machine cannot be found or created.
+    """
+
+    # Re-use instance if it already exists, or create a new one.
+    try:
+      instance = self.GetInstance(vm_name)
+      if instance:
+        created = False
+        return instance, created
+    except RuntimeError:
+      pass
+
+    # Validate SSH public key format
+    try:
+      sshpubkeys.SSHKey(ssh_public_key, strict=True).parse()
+    except sshpubkeys.InvalidKeyError as exception:
+      raise RuntimeError('The provided public SSH key is invalid: '
+                         '{0:s}'.format(str(exception)))
+
+    instance_type = self._GetInstanceType(cpu_cores, memory_in_mb)
+    startup_script = utils.ReadStartupScript()
+    if packages:
+      startup_script = startup_script.replace('${packages[@]}', ' '.join(
+          packages))
+
+    if not region:
+      region = self.az_account.default_region
+
+    creation_data = {
+        'location': region,
+        'properties': {
+            'hardwareProfile': {'vmSize': instance_type},
+            'storageProfile': {
+                'imageReference': {
+                    'sku': '18.04-LTS',
+                    'publisher': 'Canonical',
+                    'version': 'latest',
+                    'offer': 'UbuntuServer'}
+            },
+            'osDisk': {
+                'caching': 'ReadWrite',
+                'managedDisk': {'storageAccountType': 'Standard_LRS'},
+                'name': 'os-disk-{0:s}'.format(vm_name),
+                'diskSizeGb': boot_disk_size,
+                'createOption': models.DiskCreateOption.from_image
+            },
+            'osProfile': {
+                'adminUsername': 'AzureUser',
+                'computerName': vm_name,
+                # Azure requires the startup script to be sent as a b64 string
+                'customData': base64.b64encode(
+                    str.encode(startup_script)).decode('utf-8'),
+                'linuxConfiguration': {
+                    'ssh': {
+                        'publicKeys': [{
+                            'path': '/home/AzureUser/.ssh/authorized_keys',
+                            'keyData': ssh_public_key}]
+                    }
+                }
+            },
+            'networkProfile': {
+                'networkInterfaces': [
+                    # pylint: disable=line-too-long
+                    # This is necessary when creating a VM from the SDK.
+                    # See https://docs.microsoft.com/en-us/azure/virtual-machines/windows/python
+                    # pylint: enable=line-too-long
+                    {'id': self.az_account.network.CreateNetworkInterface(
+                        vm_name, region)}
+                ]
+            }
+        }
+    }  # type: Dict[str, Any]
+
+    if tags:
+      creation_data['tags'] = tags
+
+    try:
+      request = self.compute_client.virtual_machines.create_or_update(
+          self.az_account.default_resource_group_name,
+          vm_name,
+          creation_data
+      )
+      while not request.done():
+        sleep(5)  # Wait 5 seconds before checking disk status again
+      vm = request.result()
+    except azure_exceptions.CloudError as exception:
+      raise RuntimeError('Could not create instance {0:s}: {1:s}'.format(
+          vm_name, str(exception)))
+
+    instance = AZComputeVirtualMachine(self.az_account,
+                                       vm.id,
+                                       vm.name,
+                                       vm.location,
+                                       zones=vm.zones)
+    created = True
+    return instance, created
+
+  def ListInstanceTypes(self,
+                        region: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Returns a list of available VM sizes for a given region.
+
+    Args:
+      region (str): Optional. The region in which to look the instance types.
+          By default, look in the default_region associated to the AZAccount
+          object.
+
+    Returns:
+      List[Dict[str, str]]: A list of available vm size. Each size is a
+          dictionary containing the name of the configuration, the number of
+          CPU cores, and the amount of available memory (in MB).
+          E.g.: {'Name': 'Standard_B1ls', 'CPU': 1, 'Memory': 512}
+    """
+    if not region:
+      region = self.az_account.default_region
+    available_vms = self.compute_client.virtual_machine_sizes.list(region)
+    vm_sizes = []
+    for vm in available_vms:
+      vm_sizes.append({
+          'Name': vm.name,
+          'CPU': vm.number_of_cores,
+          'Memory': vm.memory_in_mb
+      })
+    return vm_sizes
+
+  def _GetInstanceType(self, cpu_cores: int, memory_in_mb: int) -> str:
+    """Returns an instance type for the given number of CPU cores / memory.
+
+    Args:
+      cpu_cores (int): The number of CPU cores.
+      memory_in_mb (int): The amount of memory (in MB).
+
+    Returns:
+      str: The instance type for the given configuration.
+
+    Raises:
+      ValueError: If no instance type matches the requested configuration.
+    """
+    vm_sizes = self.ListInstanceTypes()
+    for size in vm_sizes:
+      if size['CPU'] == cpu_cores and size['Memory'] == memory_in_mb:
+        instance_type = size['Name']  # type: str
+        return instance_type
+    raise ValueError(
+        'No instance type found for the requested configuration: {0:d} CPU '
+        'cores, {1:d} MB memory.'.format(cpu_cores, memory_in_mb))
 
 
-class AZVirtualMachine(AZComputeResource):
+class AZComputeVirtualMachine(compute_base_resource.AZComputeResource):
   """Class that represents Azure virtual machines."""
 
   def __init__(self,
@@ -85,7 +554,7 @@ class AZVirtualMachine(AZComputeResource):
                name: str,
                region: str,
                zones: Optional[List[str]] = None) -> None:
-    """Initialize the AZVirtualMachine class.
+    """Initialize the AZComputeVirtualMachine class.
 
     Args:
       az_account (AZAccount): An Azure account object.
@@ -95,24 +564,26 @@ class AZVirtualMachine(AZComputeResource):
       zones (List[str]): Optional. Availability zones within the region where
           the virtual machine is located / replicated.
     """
-    super(AZVirtualMachine, self).__init__(az_account,
-                                           resource_id,
-                                           name,
-                                           region,
-                                           zones=zones)
+    super(AZComputeVirtualMachine, self).__init__(az_account,
+                                                  resource_id,
+                                                  name,
+                                                  region,
+                                                  zones=zones)
 
-  def GetBootDisk(self) -> 'AZDisk':
+  def GetBootDisk(self) -> 'AZComputeDisk':
     """Get the instance's boot disk.
 
     Returns:
-      AZDisk: Disk object if the disk is found.
+      AZComputeDisk: Disk object if the disk is found.
 
     Raises:
       RuntimeError: If no boot disk could be found.
     """
-    disks = self.az_account.ListDisks(
-        resource_group_name=self.resource_group_name)  # type: Dict[str, AZDisk]
-    boot_disk_name = self.az_account.compute_client.virtual_machines.get(
+    # pylint: disable=line-too-long
+    disks = self.az_account.compute.ListDisks(
+        resource_group_name=self.resource_group_name)  # type: Dict[str, AZComputeDisk]
+    # pylint: enable=line-too-long
+    boot_disk_name = self.compute_client.virtual_machines.get(
         self.resource_group_name, self.name).storage_profile.os_disk.name
     if boot_disk_name not in disks:
       error_msg = 'Boot disk not found for instance: {0:s}'.format(
@@ -120,14 +591,14 @@ class AZVirtualMachine(AZComputeResource):
       raise RuntimeError(error_msg)
     return disks[boot_disk_name]
 
-  def GetDisk(self, disk_name: str) -> 'AZDisk':
+  def GetDisk(self, disk_name: str) -> 'AZComputeDisk':
     """Get a disk attached to the instance by ID.
 
     Args:
       disk_name (str): The ID of the disk to get.
 
     Returns:
-      AZDisk: The disk object.
+      AZComputeDisk: The disk object.
 
     Raises:
       RuntimeError: If disk_name is not found amongst the disks attached
@@ -140,31 +611,31 @@ class AZVirtualMachine(AZComputeResource):
       raise RuntimeError(error_msg)
     return disks[disk_name]
 
-  def ListDisks(self) -> Dict[str, 'AZDisk']:
+  def ListDisks(self) -> Dict[str, 'AZComputeDisk']:
     """List all disks for the instance.
 
     Returns:
-      Dict[str, AZDisk]: Dictionary mapping disk names to their respective
-          AZDisk object.
+      Dict[str, AZComputeDisk]: Dictionary mapping disk names to their
+          respective AZComputeDisk object.
     """
-    disks = self.az_account.ListDisks(
+    disks = self.az_account.compute.ListDisks(
         resource_group_name=self.resource_group_name)
-    vm_disks = self.az_account.compute_client.virtual_machines.get(
+    vm_disks = self.compute_client.virtual_machines.get(
         self.resource_group_name, self.name).storage_profile
     vm_disks_names = [disk.name for disk in vm_disks.data_disks]
     vm_disks_names.append(vm_disks.os_disk.name)
     return {disk_name: disks[disk_name] for disk_name in vm_disks_names}
 
-  def AttachDisk(self, disk: 'AZDisk') -> None:
+  def AttachDisk(self, disk: 'AZComputeDisk') -> None:
     """Attach a disk to the virtual machine.
 
     Args:
-      disk (AZDisk): Disk to attach.
+      disk (AZComputeDisk): Disk to attach.
 
     Raises:
       RuntimeError: If the disk could not be attached.
     """
-    vm = self.az_account.compute_client.virtual_machines.get(
+    vm = self.compute_client.virtual_machines.get(
         self.resource_group_name, self.name)
     data_disks = vm.storage_profile.data_disks
     # ID to assign to the data disk to attach
@@ -180,7 +651,7 @@ class AZVirtualMachine(AZComputeResource):
     data_disks.append(update_data)
 
     try:
-      request = self.az_account.compute_client.virtual_machines.update(
+      request = self.compute_client.virtual_machines.update(
           self.resource_group_name, self.name, vm)
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking vm status again
@@ -189,7 +660,7 @@ class AZVirtualMachine(AZComputeResource):
                          '{2:s}'.format(disk.name, self.name, str(exception)))
 
 
-class AZDisk(AZComputeResource):
+class AZComputeDisk(compute_base_resource.AZComputeResource):
   """Class that represents Azure disks."""
 
   def __init__(self,
@@ -198,7 +669,7 @@ class AZDisk(AZComputeResource):
                name: str,
                region: str,
                zones: Optional[List[str]] = None) -> None:
-    """Initialize the AZDisk class.
+    """Initialize the AZComputeDisk class.
 
     Args:
       az_account (AZAccount): An Azure account object.
@@ -208,15 +679,15 @@ class AZDisk(AZComputeResource):
       zones (List[str]): Optional. Availability zone within the region where
           the disk is located.
     """
-    super(AZDisk, self).__init__(az_account,
-                                 resource_id,
-                                 name,
-                                 region,
-                                 zones=zones)
+    super(AZComputeDisk, self).__init__(az_account,
+                                        resource_id,
+                                        name,
+                                        region,
+                                        zones=zones)
 
   def Snapshot(self,
                snapshot_name: Optional[str] = None,
-               tags: Optional[Dict[str, str]] = None) -> 'AZSnapshot':
+               tags: Optional[Dict[str, str]] = None) -> 'AZComputeSnapshot':
     """Create a snapshot of the disk.
 
     Args:
@@ -226,7 +697,7 @@ class AZDisk(AZComputeResource):
           snapshot, for example {'TicketID': 'xxx'}.
 
     Returns:
-      AZSnapshot: A snapshot object.
+      AZComputeSnapshot: A snapshot object.
 
     Raises:
       ValueError: If the snapshot name does not comply with the RegEx.
@@ -255,7 +726,7 @@ class AZDisk(AZComputeResource):
 
     try:
       logger.info('Creating snapshot: {0:s}'.format(snapshot_name))
-      request = self.az_account.compute_client.snapshots.create_or_update(
+      request = self.compute_client.snapshots.create_or_update(
           self.resource_group_name,
           snapshot_name,
           creation_data)
@@ -267,11 +738,11 @@ class AZDisk(AZComputeResource):
       raise RuntimeError('Could not create snapshot for disk {0:s}: {1:s}'
                          .format(self.resource_id, str(exception)))
 
-    return AZSnapshot(self.az_account,
-                      snapshot.id,
-                      snapshot.name,
-                      snapshot.location,
-                      self)
+    return AZComputeSnapshot(self.az_account,
+                             snapshot.id,
+                             snapshot.name,
+                             snapshot.location,
+                             self)
 
   def GetDiskType(self) -> str:
     """Return the SKU disk type.
@@ -279,17 +750,17 @@ class AZDisk(AZComputeResource):
     Returns:
       str: The SKU disk type.
     """
-    disk = self.az_account.compute_client.disks.get(
+    disk = self.compute_client.disks.get(
         self.resource_group_name, self.name)
     disk_type = disk.sku.name  # type: str
     return disk_type
 
 
-class AZSnapshot(AZComputeResource):
+class AZComputeSnapshot(compute_base_resource.AZComputeResource):
   """Class that represents Azure snapshots.
 
   Attributes:
-    disk (AZDisk): The disk from which the snapshot was taken.
+    disk (AZComputeDisk): The disk from which the snapshot was taken.
   """
 
   def __init__(self,
@@ -297,20 +768,20 @@ class AZSnapshot(AZComputeResource):
                resource_id: str,
                name: str,
                region: str,
-               source_disk: AZDisk) -> None:
-    """Initialize the AZDisk class.
+               source_disk: AZComputeDisk) -> None:
+    """Initialize the AZComputeDisk class.
 
     Args:
       az_account (AZAccount): An Azure account object.
       resource_id (str): The Azure ID of the snapshot.
       name (str): The snapshot name.
       region (str): The region in which the snapshot is located.
-      source_disk (AZDisk): The disk from which the snapshot was taken.
+      source_disk (AZComputeDisk): The disk from which the snapshot was taken.
     """
-    super(AZSnapshot, self).__init__(az_account,
-                                     resource_id,
-                                     name,
-                                     region)
+    super(AZComputeSnapshot, self).__init__(az_account,
+                                            resource_id,
+                                            name,
+                                            region)
 
     self.disk = source_disk
 
@@ -319,7 +790,7 @@ class AZSnapshot(AZComputeResource):
 
     try:
       logger.info('Deleting snapshot: {0:s}'.format(self.name))
-      request = self.az_account.compute_client.snapshots.delete(
+      request = self.compute_client.snapshots.delete(
           self.resource_group_name, self.name)
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking snapshot status again
@@ -335,7 +806,7 @@ class AZSnapshot(AZComputeResource):
       str: The access URI for the snapshot.
     """
     logger.info('Generating SAS URI for snapshot: {0:s}'.format(self.name))
-    access_request = self.az_account.compute_client.snapshots.grant_access(
+    access_request = self.compute_client.snapshots.grant_access(
         self.resource_group_name, self.name, 'Read', 3600)
     snapshot_uri = access_request.result().access_sas  # type: str
     logger.info('SAS URI generated: {0:s}'.format(snapshot_uri))
@@ -344,7 +815,7 @@ class AZSnapshot(AZComputeResource):
   def RevokeAccessURI(self) -> None:
     """Revoke access to a snapshot."""
     logger.info('Revoking SAS URI for snapshot {0:s}'.format(self.name))
-    request = self.az_account.compute_client.snapshots.revoke_access(
+    request = self.compute_client.snapshots.revoke_access(
         self.resource_group_name, self.name)
     request.wait()
     logger.info('SAS URI revoked for snapshot {0:s}'.format(self.name))

--- a/libcloudforensics/providers/azure/internal/compute_base_resource.py
+++ b/libcloudforensics/providers/azure/internal/compute_base_resource.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class AZComputeResource:
-  """Class that represent an Azure compute resource
+  """Class that represent an Azure compute resource.
 
   Attributes:
     az_account (AZAccount): An Azure account object.
@@ -66,7 +66,7 @@ class AZComputeResource:
   @property
   def compute_client(self) -> compute_sdk.ComputeManagementClient:
     """Return the Azure compute client object associated to the Azure
-    account.
+        account.
 
     Returns:
       ComputeManagementClient: An Azure compute client object.

--- a/libcloudforensics/providers/azure/internal/compute_base_resource.py
+++ b/libcloudforensics/providers/azure/internal/compute_base_resource.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Azure Compute Base Resource."""
+
+from typing import Optional, List, TYPE_CHECKING
+
+from azure.mgmt import compute as compute_sdk  # pylint: disable=import-error
+
+if TYPE_CHECKING:
+  # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
+  # the following cyclic import, as it it only used for type hints
+  from libcloudforensics.providers.azure.internal import account  # pylint: disable=cyclic-import
+
+
+class AZComputeResource:
+  """Class that represent an Azure compute resource
+
+  Attributes:
+    az_account (AZAccount): An Azure account object.
+    resource_group_name (str): The Azure resource group name for the resource.
+    resource_id (str): The Azure resource ID.
+    name (str): The resource's name.
+    region (str): The region in which the resource is located.
+    zones (List[str]): Optional. Availability zones within the region where
+        the resource is located.
+  """
+
+  def __init__(self,
+               az_account: 'account.AZAccount',
+               resource_id: str,
+               name: str,
+               region: str,
+               zones: Optional[List[str]] = None) -> None:
+    """Initialize the AZComputeResource class.
+
+    Args:
+      az_account (AZAccount): An Azure account object.
+      resource_id (str): The Azure resource ID.
+      name (str): The resource's name.
+      region (str): The region in which the resource is located.
+      zones (List[str]): Optional. Availability zones within the region where
+          the resource is located.
+    """
+
+    self.az_account = az_account
+    # Format of resource_id: /subscriptions/{id}/resourceGroups/{
+    # resource_group_name}/providers/Microsoft.Compute/{resourceType}/{resource}
+    self.resource_group_name = resource_id.split('/')[4]
+    self.resource_id = resource_id
+    self.name = name
+    self.region = region
+    self.zones = zones
+
+  @property
+  def compute_client(self) -> compute_sdk.ComputeManagementClient:
+    """Return the Azure compute client object associated to the Azure
+    account.
+
+    Returns:
+      ComputeManagementClient: An Azure compute client object.
+    """
+    return self.az_account.compute.compute_client

--- a/libcloudforensics/providers/azure/internal/compute_base_resource.py
+++ b/libcloudforensics/providers/azure/internal/compute_base_resource.py
@@ -18,6 +18,8 @@ from typing import Optional, List, TYPE_CHECKING
 
 from azure.mgmt import compute as compute_sdk  # pylint: disable=import-error
 
+from libcloudforensics.providers.azure.internal import common  # pylint: disable=ungrouped-imports
+
 if TYPE_CHECKING:
   # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
   # the following cyclic import, as it it only used for type hints
@@ -52,7 +54,15 @@ class AZComputeResource:
       region (str): The region in which the resource is located.
       zones (List[str]): Optional. Availability zones within the region where
           the resource is located.
+
+    Raises:
+      ValueError: If the resource ID is malformed.
     """
+
+    if not common.REGEX_COMPUTE_RESOURCE_ID.match(resource_id):
+      raise ValueError(
+          'Malformed resource ID: expected {0:s}, got {1:s}'.format(
+              common.REGEX_COMPUTE_RESOURCE_ID.pattern, resource_id))
 
     self.az_account = az_account
     # Format of resource_id: /subscriptions/{id}/resourceGroups/{

--- a/libcloudforensics/providers/azure/internal/monitoring.py
+++ b/libcloudforensics/providers/azure/internal/monitoring.py
@@ -23,9 +23,10 @@ from azure.mgmt.monitor import MonitorManagementClient
 from azure.mgmt.monitor.v2018_01_01 import models
 # pylint: enable=import-error
 
-from libcloudforensics.providers.azure.internal import account
-
 if TYPE_CHECKING:
+  # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
+  # the following cyclic import, as it it only used for type hints
+  from libcloudforensics.providers.azure.internal import account  # pylint: disable=cyclic-import
   from datetime import datetime
 
 
@@ -33,21 +34,19 @@ class AZMonitoring:
   """Azure Monitoring.
 
   Attributes:
-    az_account (AZAccount): An Azure account object.
     monitoring_client (MonitorManagementClient): An Azure monitoring client
         object.
   """
 
   def __init__(self,
-               az_account: account.AZAccount) -> None:
+               az_account: 'account.AZAccount') -> None:
     """Initialize the Azure monitoring class.
 
     Args:
       az_account (AZAccount): An Azure account object.
     """
-    self.az_account = az_account
     self.monitoring_client = MonitorManagementClient(
-        self.az_account.credentials, self.az_account.subscription_id)
+        az_account.credentials, az_account.subscription_id)
 
   def ListAvailableMetricsForResource(self, resource_id: str) -> List[str]:
     """List the available metrics for a given resource.

--- a/libcloudforensics/providers/azure/internal/network.py
+++ b/libcloudforensics/providers/azure/internal/network.py
@@ -82,7 +82,8 @@ class AZNetwork:
       return nic_id
     except azure_exceptions.CloudError as exception:
       if 'ResourceNotFound' not in exception.error.error:
-        raise exception
+        raise RuntimeError('Could not create network interface: {0:s}'.format(
+            str(exception)))
       # NIC doesn't exist, ignore the error and create it
 
     # pylint: disable=unbalanced-tuple-unpacking

--- a/libcloudforensics/providers/azure/internal/network.py
+++ b/libcloudforensics/providers/azure/internal/network.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Azure Networking functionality."""
+
+from typing import TYPE_CHECKING, Optional, Tuple, Any, Dict
+
+# pylint: disable=import-error
+from azure.mgmt import network
+from msrestazure import azure_exceptions
+# pylint: enable=import-error
+
+from libcloudforensics.providers.azure.internal import common
+
+if TYPE_CHECKING:
+  # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
+  # the following cyclic import, as it it only used for type hints
+  from libcloudforensics.providers.azure.internal import account  # pylint: disable=cyclic-import
+
+
+class AZNetwork:
+  """Azure Networking functionality.
+
+  Attributes:
+    az_account (AZAccount): An Azure account object.
+    network_client (NetworkManagementClient): An Azure network client object.
+  """
+
+  def __init__(self,
+               az_account: 'account.AZAccount') -> None:
+    """Initialize the Azure network class.
+
+    Args:
+      az_account (AZAccount): An Azure account object.
+    """
+    self.az_account = az_account
+    self.network_client = network.NetworkManagementClient(
+        self.az_account.credentials, self.az_account.subscription_id)
+
+  def CreateNetworkInterface(self,
+                             name: str,
+                             region: Optional[str] = None) -> str:
+    """Create a network interface and returns its ID.
+
+    Args:
+      name (str): The name of the network interface.
+      region (str): Optional. The region in which to create the network
+          interface. Default uses default_region of the AZAccount object.
+
+    Returns:
+      str: The id of the created network interface.
+
+    Raises:
+      ValueError: if name is not provided.
+      RuntimeError: If no network interface could be created.
+    """
+    if not name:
+      raise ValueError('name must be specified. Provided: {0!s}'.format(name))
+
+    if not region:
+      region = self.az_account.default_region
+
+    network_interface_name = '{0:s}-nic'.format(name)
+    ip_config_name = '{0:s}-ipconfig'.format(name)
+
+    # Check if the network interface already exists, and returns its ID if so.
+    try:
+      nic = self.network_client.network_interfaces.get(
+          self.az_account.default_resource_group_name, network_interface_name)
+      nic_id = nic.id  # type: str
+      return nic_id
+    except azure_exceptions.CloudError:
+      # NIC doesn't exist, ignore the error and create it
+      pass
+
+    # pylint: disable=unbalanced-tuple-unpacking
+    public_ip, _, subnet = self._CreateNetworkInterfaceElements(
+        name, region=region)
+    # pylint: enable=unbalanced-tuple-unpacking
+
+    creation_data = {
+        'location': region,
+        'ip_configurations': [{
+            'name': ip_config_name,
+            'public_ip_address': public_ip,
+            'subnet': {
+                'id': subnet.id
+            }
+        }]
+    }
+
+    try:
+      request = self.network_client.network_interfaces.create_or_update(
+          self.az_account.default_resource_group_name,
+          network_interface_name,
+          creation_data)
+      request.wait()
+    except azure_exceptions.CloudError as exception:
+      raise RuntimeError('Could not create network interface: {0:s}'.format(
+          str(exception)))
+
+    network_interface_id = request.result().id  # type: str
+    return network_interface_id
+
+  def _CreateNetworkInterfaceElements(
+      self,
+      name_prefix: str,
+      region: Optional[str] = None) -> Tuple[Any, ...]:
+    """Creates required elements for creating a network interface.
+
+    Args:
+      name_prefix (str): A name prefix to use for the network interface
+          elements to create.
+      region (str): Optional. The region in which to create the elements.
+          Default uses default_region of the AZAccount object.
+
+    Returns:
+      Tuple[Any, Any, Any]: A tuple containing a public IP address object,
+          a virtual network object and a subnet object.
+
+    Raises:
+      RuntimeError: If the elements could not be created.
+    """
+
+    if not region:
+      region = self.az_account.default_region
+
+    public_ip_name = '{0:s}-public-ip'.format(name_prefix)
+    vnet_name = '{0:s}-vnet'.format(name_prefix)
+    subnet_name = '{0:s}-subnet'.format(name_prefix)
+
+    client_to_creation_data = {
+        self.network_client.public_ip_addresses: {
+            'resource_group_name': self.az_account.default_resource_group_name,
+            'public_ip_address_name': public_ip_name,
+            'parameters': {
+                'location': region,
+                'public_ip_allocation_method': 'Dynamic'
+            }
+        },
+        self.network_client.virtual_networks: {
+            'resource_group_name': self.az_account.default_resource_group_name,
+            'virtual_network_name': vnet_name,
+            'parameters': {
+                'location': region,
+                'address_space': {'address_prefixes': ['10.0.0.0/16']}
+            }
+        },
+        self.network_client.subnets: {
+            'resource_group_name': self.az_account.default_resource_group_name,
+            'virtual_network_name': vnet_name,
+            'subnet_name': subnet_name,
+            'subnet_parameters': {
+                'address_prefix': '10.0.0.0/24'
+            }
+        }
+    }  # type: Dict[str, Any]
+
+    result = []
+    try:
+      for client in client_to_creation_data:
+        request = common.ExecuteRequest(
+            client, 'create_or_update', client_to_creation_data[client])[0]
+        request.wait()
+        result.append(request.result())
+    except azure_exceptions.CloudError as exception:
+      raise RuntimeError('Could not create network interface elements: '
+                         '{0:s}'.format(str(exception)))
+    return tuple(result)

--- a/libcloudforensics/providers/azure/internal/network.py
+++ b/libcloudforensics/providers/azure/internal/network.py
@@ -80,9 +80,10 @@ class AZNetwork:
           self.az_account.default_resource_group_name, network_interface_name)
       nic_id = nic.id  # type: str
       return nic_id
-    except azure_exceptions.CloudError:
+    except azure_exceptions.CloudError as exception:
+      if 'ResourceNotFound' not in exception.error.error:
+        raise exception
       # NIC doesn't exist, ignore the error and create it
-      pass
 
     # pylint: disable=unbalanced-tuple-unpacking
     public_ip, _, subnet = self._CreateNetworkInterfaceElements(

--- a/libcloudforensics/providers/azure/internal/resource.py
+++ b/libcloudforensics/providers/azure/internal/resource.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Azure Resource functionality."""
+
+from typing import TYPE_CHECKING, List
+
+# pylint: disable=import-error
+from azure.mgmt import resource
+from msrestazure import azure_exceptions
+# pylint: enable=import-error
+
+from libcloudforensics import logging_utils
+
+if TYPE_CHECKING:
+  # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
+  # the following cyclic import, as it it only used for type hints
+  from libcloudforensics.providers.azure.internal import account  # pylint: disable=cyclic-import
+
+
+logging_utils.SetUpLogger(__name__)
+logger = logging_utils.GetLogger(__name__)
+
+
+class AZResource:
+  """Azure resource functionality.
+
+  Attributes:
+    az_account (AZAccount): An Azure account object.
+    resource_client (ResourceManagementClient): An Azure resource client object.
+    subscription_client (SubscriptionClient): An Azure subscription client
+        object.
+  """
+
+  def __init__(self,
+               az_account: 'account.AZAccount') -> None:
+    """Initialize the Azure resource class.
+
+    Args:
+      az_account (AZAccount): An Azure account object.
+    """
+    self.az_account = az_account
+    self.resource_client = resource.ResourceManagementClient(
+        self.az_account.credentials, self.az_account.subscription_id)
+    self.subscription_client = resource.SubscriptionClient(
+        self.az_account.credentials)
+
+  def GetOrCreateResourceGroup(self, resource_group_name: str) -> str:
+    """Check if a resource group exists, and create it otherwise.
+
+    Args:
+      resource_group_name (str); The name of the resource group to check
+          existence for. If it does not exist, create it.
+
+    Returns:
+      str: The resource group name.
+    """
+    try:
+      self.resource_client.resource_groups.get(resource_group_name)
+    except azure_exceptions.CloudError:
+      # Group doesn't exist, creating it
+      logger.info('Resource group {0:s} not found, creating it.'.format(
+          resource_group_name))
+      creation_data = {
+          'location': self.az_account.default_region
+      }
+      self.resource_client.resource_groups.create_or_update(
+          resource_group_name, creation_data)
+      logger.info('Resource group {0:s} successfully created.'.format(
+          resource_group_name))
+    return resource_group_name
+
+  def ListSubscriptionIDs(self) -> List[str]:
+    """List subscription ids from an Azure account.
+
+    Returns:
+      List[str]: A list of all subscription IDs from the Azure account.
+    """
+    subscription_ids = self.subscription_client.subscriptions.list()
+    return [sub.subscription_id for sub in subscription_ids]

--- a/libcloudforensics/providers/azure/internal/storage.py
+++ b/libcloudforensics/providers/azure/internal/storage.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Azure Storage functionality."""
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+# pylint: disable=import-error
+from azure.mgmt import storage
+from msrestazure import azure_exceptions
+# pylint: enable=import-error
+
+from libcloudforensics import logging_utils
+from libcloudforensics.providers.azure.internal import common
+
+if TYPE_CHECKING:
+  # TYPE_CHECKING is always False at runtime, therefore it is safe to ignore
+  # the following cyclic import, as it it only used for type hints
+  from libcloudforensics.providers.azure.internal import account  # pylint: disable=cyclic-import
+
+
+logging_utils.SetUpLogger(__name__)
+logger = logging_utils.GetLogger(__name__)
+
+
+class AZStorage:
+  """Azure Storage functionality.
+
+  Attributes:
+    az_account (AZAccount): An Azure account object.
+    storage_client (StorageManagementClient): An Azure storage client object.
+  """
+
+  def __init__(self,
+               az_account: 'account.AZAccount') -> None:
+    """Initialize the Azure storage class.
+
+    Args:
+      az_account (AZAccount): An Azure account object.
+    """
+    self.az_account = az_account
+    self.storage_client = storage.StorageManagementClient(
+        self.az_account.credentials, self.az_account.subscription_id)
+
+  def CreateStorageAccount(self,
+                           storage_account_name: str,
+                           region: Optional[str] = None) -> Tuple[str, str]:
+    """Create a storage account and returns its ID and access key.
+
+    Args:
+      storage_account_name (str): The name for the storage account.
+      region (str): Optional. The region in which to create the storage
+          account. If not provided, it will be created in the default_region
+          associated to the AZAccount object.
+
+    Returns:
+      Tuple[str, str]: The storage account ID and its access key.
+
+    Raises:
+      ValueError: If the storage account name is invalid.
+    """
+
+    if not common.REGEX_ACCOUNT_STORAGE_NAME.match(storage_account_name):
+      raise ValueError(
+          'Storage account name {0:s} does not comply with {1:s}'.format(
+              storage_account_name, common.REGEX_ACCOUNT_STORAGE_NAME.pattern))
+
+    if not region:
+      region = self.az_account.default_region
+
+    # https://docs.microsoft.com/en-us/rest/api/storagerp/srp_sku_types
+    creation_data = {
+        'location': region,
+        'sku': {
+            'name': 'Standard_RAGRS'
+        },
+        'kind': 'Storage'
+    }
+
+    # pylint: disable=line-too-long
+    # https://docs.microsoft.com/en-us/samples/azure-samples/storage-python-manage/storage-python-manage/
+    # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python
+    # pylint: enable=line-too-long
+    logger.info('Creating storage account: {0:s}'.format(storage_account_name))
+    request = self.storage_client.storage_accounts.create(
+        self.az_account.default_resource_group_name,
+        storage_account_name,
+        creation_data
+    )
+    logger.info('Storage account {0:s} successfully created'.format(
+        storage_account_name))
+    storage_account = request.result()
+    storage_account_keys = self.storage_client.storage_accounts.list_keys(
+        self.az_account.default_resource_group_name, storage_account_name)
+    storage_account_keys = {key.key_name: key.value
+                            for key in storage_account_keys.keys}
+    storage_account_id = storage_account.id  # type: str
+    storage_account_key = storage_account_keys['key1']  # type: str
+    return storage_account_id, storage_account_key
+
+  def DeleteStorageAccount(self, storage_account_name: str) -> None:
+    """Delete an account storage.
+
+    Raises:
+      RuntimeError: if the storage account could not be deleted.
+    """
+    try:
+      logger.info('Deleting storage account: {0:s}'.format(
+          storage_account_name))
+      self.storage_client.storage_accounts.delete(
+          self.az_account.default_resource_group_name, storage_account_name)
+      logger.info('Storage account {0:s} successfully deleted'.format(
+          storage_account_name))
+    except azure_exceptions.CloudError as exception:
+      raise RuntimeError('Could not delete account storage {0:s}: {1:s}'
+                         .format(storage_account_name, str(exception)))

--- a/tests/providers/azure/azure_e2e.py
+++ b/tests/providers/azure/azure_e2e.py
@@ -85,7 +85,7 @@ class EndToEndTest(unittest.TestCase):
         # disk_name=None by default, boot disk of instance will be copied
     )
     # The disk should be present in Azure
-    remote_disk = self.az.compute_client.disks.get(
+    remote_disk = self.az.compute.compute_client.disks.get(
         disk_copy.resource_group_name, disk_copy.name)
     self.assertIsNotNone(remote_disk)
     self.assertEqual(disk_copy.name, remote_disk.name)
@@ -105,7 +105,7 @@ class EndToEndTest(unittest.TestCase):
         self.resource_group_name,
         disk_name=self.disk_to_copy)
     # The disk should be present in Azure
-    remote_disk = self.az.compute_client.disks.get(
+    remote_disk = self.az.compute.compute_client.disks.get(
         disk_copy.resource_group_name, disk_copy.name)
     self.assertIsNotNone(remote_disk)
     self.assertEqual(disk_copy.name, remote_disk.name)
@@ -113,7 +113,7 @@ class EndToEndTest(unittest.TestCase):
     # Since we make a copy of the same disk but in a different region in next
     # test, we need to delete the copy we just created as Azure does not
     # permit same-name disks in different regions.
-    self.az.compute_client.disks.delete(
+    self.az.compute.compute_client.disks.delete(
         disk_copy.resource_group_name, disk_copy.name)
 
   @typing.no_type_check
@@ -131,7 +131,7 @@ class EndToEndTest(unittest.TestCase):
         disk_name=self.disk_to_copy,
         region=self.dst_region)
     # The disk should be present in Azure and be in self.dst_region
-    remote_disk = self.az.compute_client.disks.get(
+    remote_disk = self.az.compute.compute_client.disks.get(
         disk_copy.resource_group_name, disk_copy.name)
     self.assertIsNotNone(remote_disk)
     self.assertEqual(disk_copy.name, remote_disk.name)
@@ -161,7 +161,7 @@ class EndToEndTest(unittest.TestCase):
 
     # The forensic instance should be live in the analysis Azure account and
     # the disk should be attached
-    instance = self.az.compute_client.virtual_machines.get(
+    instance = self.az.compute.compute_client.virtual_machines.get(
         self.resource_group_name, self.analysis_vm.name)
     self.assertEqual(instance.name, self.analysis_vm.name)
     self.assertIn(disk_copy.name, self.analysis_vm.ListDisks())
@@ -181,7 +181,7 @@ class EndToEndTest(unittest.TestCase):
   def tearDownClass(cls):
     # Delete the instance
     logger.info('Deleting instance: {0:s}.'.format(cls.analysis_vm.name))
-    request = cls.az.compute_client.virtual_machines.delete(
+    request = cls.az.compute.compute_client.virtual_machines.delete(
         cls.analysis_vm.resource_group_name, cls.analysis_vm.name)
     while not request.done():
       sleep(5)  # Wait 5 seconds before checking vm deletion status again
@@ -190,22 +190,23 @@ class EndToEndTest(unittest.TestCase):
     # Delete the network interface and associated artifacts created for the
     # analysis VM
     logger.info('Deleting network artifacts...')
-    cls.az.network_client.network_interfaces.delete(
+    cls.az.network.network_client.network_interfaces.delete(
         cls.resource_group_name, '{0:s}-nic'.format(cls.analysis_vm_name))
-    cls.az.network_client.subnets.delete(
+    cls.az.network.network_client.subnets.delete(
         cls.resource_group_name,
         '{0:s}-vnet'.format(cls.analysis_vm_name),
         '{0:s}-subnet'.format(cls.analysis_vm_name))
-    cls.az.network_client.virtual_networks.delete(
+    cls.az.network.network_client.virtual_networks.delete(
         cls.resource_group_name, '{0:s}-vnet'.format(cls.analysis_vm_name))
-    cls.az.network_client.public_ip_addresses.delete(
+    cls.az.network.network_client.public_ip_addresses.delete(
         cls.resource_group_name, '{0:s}-public-ip'.format(
             cls.analysis_vm_name))
     # Delete the disks
     for disk in cls.disks:
       logger.info('Deleting disk: {0:s}.'.format(disk.name))
       try:
-        cls.az.compute_client.disks.delete(disk.resource_group_name, disk.name)
+        cls.az.compute.compute_client.disks.delete(
+            disk.resource_group_name, disk.name)
       except azure_exceptions.CloudError as exception:
         raise RuntimeError('Could not complete cleanup: {0:s}'.format(
             str(exception)))

--- a/tests/providers/azure/azure_e2e.py
+++ b/tests/providers/azure/azure_e2e.py
@@ -136,7 +136,12 @@ class EndToEndTest(unittest.TestCase):
     self.assertIsNotNone(remote_disk)
     self.assertEqual(disk_copy.name, remote_disk.name)
     self.assertEqual(self.dst_region, remote_disk.location)
-    self._StoreDiskForCleanup(disk_copy)
+
+    # Since we make a copy of the same disk but in a different region in next
+    # test, we need to delete the copy we just created as Azure does not
+    # permit same-name disks in different regions.
+    self.az.compute.compute_client.disks.delete(
+        disk_copy.resource_group_name, disk_copy.name)
 
   @typing.no_type_check
   def testStartVm(self):

--- a/tests/providers/azure/azure_test.py
+++ b/tests/providers/azure/azure_test.py
@@ -26,7 +26,7 @@ from libcloudforensics.providers.azure import forensics
 # pylint: disable=line-too-long
 with mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials') as mock_creds:
   mock_creds.return_value = ('fake-subscription-id', mock.Mock())
-  with mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup') as mock_resource:
+  with mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.GetOrCreateResourceGroup') as mock_resource:
     # pylint: enable=line-too-long
     mock_resource.return_value = 'fake-resource-group'
     FAKE_ACCOUNT = account.AZAccount(
@@ -34,7 +34,7 @@ with mock.patch('libcloudforensics.providers.azure.internal.common.GetCredential
         default_region='fake-region'
     )
 
-FAKE_INSTANCE = compute.AZVirtualMachine(
+FAKE_INSTANCE = compute.AZComputeVirtualMachine(
     FAKE_ACCOUNT,
     '/a/b/c/fake-resource-group/fake-vm-name',
     'fake-vm-name',
@@ -42,7 +42,7 @@ FAKE_INSTANCE = compute.AZVirtualMachine(
     ['fake-zone']
 )
 
-FAKE_DISK = compute.AZDisk(
+FAKE_DISK = compute.AZComputeDisk(
     FAKE_ACCOUNT,
     '/a/b/c/fake-resource-group/fake-disk-name',
     'fake-disk-name',
@@ -50,7 +50,7 @@ FAKE_DISK = compute.AZDisk(
     ['fake-zone']
 )
 
-FAKE_BOOT_DISK = compute.AZDisk(
+FAKE_BOOT_DISK = compute.AZComputeDisk(
     FAKE_ACCOUNT,
     '/a/b/c/fake-resource-group/fake-boot-disk-name',
     'fake-boot-disk-name',
@@ -58,7 +58,7 @@ FAKE_BOOT_DISK = compute.AZDisk(
     ['fake-zone']
 )
 
-FAKE_SNAPSHOT = compute.AZSnapshot(
+FAKE_SNAPSHOT = compute.AZComputeSnapshot(
     FAKE_ACCOUNT,
     '/a/b/c/fake-resource-group/fake_snapshot_name',
     'fake_snapshot_name',
@@ -167,7 +167,7 @@ class TestAccount(unittest.TestCase):
 
     # If we don't specify a resource group name, the 'list_all' method should
     # be called.
-    instances = FAKE_ACCOUNT.ListInstances()
+    instances = FAKE_ACCOUNT.compute.ListInstances()
     mock_request.assert_called_with(mock.ANY, 'list_all')
     self.assertEqual(1, len(instances))
     self.assertIn('fake-vm-name', instances)
@@ -180,7 +180,7 @@ class TestAccount(unittest.TestCase):
     self.assertEqual(['fake-zone'], instance.zones)
 
     # If we specify a resource group name, the 'list' method should be called.
-    FAKE_ACCOUNT.ListInstances(
+    FAKE_ACCOUNT.compute.ListInstances(
         resource_group_name=instance.resource_group_name)
     mock_request.assert_called_with(
         mock.ANY, 'list', {'resource_group_name': instance.resource_group_name})
@@ -193,7 +193,7 @@ class TestAccount(unittest.TestCase):
 
     # If we don't specify a resource group name, the 'list' method should be
     # called.
-    disks = FAKE_ACCOUNT.ListDisks()
+    disks = FAKE_ACCOUNT.compute.ListDisks()
     mock_request.assert_called_with(mock.ANY, 'list')
     self.assertEqual(2, len(disks))
     self.assertIn('fake-disk-name', disks)
@@ -207,18 +207,18 @@ class TestAccount(unittest.TestCase):
 
     # If we specify a resource group name, the 'list_by_resource_group' method
     # should be called.
-    FAKE_ACCOUNT.ListDisks(resource_group_name=disk.resource_group_name)
+    FAKE_ACCOUNT.compute.ListDisks(resource_group_name=disk.resource_group_name)
     mock_request.assert_called_with(
         mock.ANY,
         'list_by_resource_group',
         {'resource_group_name': disk.resource_group_name})
 
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListInstances')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListInstances')
   @typing.no_type_check
   def testGetInstance(self, mock_list_instances):
     """Test that a particular instance from an account is retrieved."""
     mock_list_instances.return_value = MOCK_LIST_INSTANCES
-    instance = FAKE_ACCOUNT.GetInstance('fake-vm-name')
+    instance = FAKE_ACCOUNT.compute.GetInstance('fake-vm-name')
     self.assertEqual('fake-vm-name', instance.name)
     self.assertEqual(
         '/a/b/c/fake-resource-group/fake-vm-name', instance.resource_id)
@@ -226,12 +226,12 @@ class TestAccount(unittest.TestCase):
     self.assertEqual('fake-region', instance.region)
     self.assertEqual(['fake-zone'], instance.zones)
 
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListDisks')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
   @typing.no_type_check
   def testGetDisk(self, mock_list_disks):
     """Test that a particular disk from an account is retrieved."""
     mock_list_disks.return_value = MOCK_LIST_DISKS
-    disk = FAKE_ACCOUNT.GetDisk('fake-disk-name')
+    disk = FAKE_ACCOUNT.compute.GetDisk('fake-disk-name')
     self.assertEqual('fake-disk-name', disk.name)
     self.assertEqual(
         '/a/b/c/fake-resource-group/fake-disk-name', disk.resource_id)
@@ -247,9 +247,9 @@ class TestAccount(unittest.TestCase):
     mock_create_disk.return_value.result.return_value = MOCK_DISK_COPY
     # CreateDiskFromSnapshot(
     #     snapshot=FAKE_SNAPSHOT, disk_name=None, disk_name_prefix='')
-    disk_from_snapshot = FAKE_ACCOUNT.CreateDiskFromSnapshot(
+    disk_from_snapshot = FAKE_ACCOUNT.compute.CreateDiskFromSnapshot(
         FAKE_SNAPSHOT)
-    self.assertIsInstance(disk_from_snapshot, compute.AZDisk)
+    self.assertIsInstance(disk_from_snapshot, compute.AZComputeDisk)
     self.assertEqual(
         'fake_snapshot_name_f4c186ac_copy', disk_from_snapshot.name)
     mock_create_disk.assert_called_with(
@@ -261,7 +261,7 @@ class TestAccount(unittest.TestCase):
     #     snapshot=FAKE_SNAPSHOT,
     #     disk_name='new-forensics-disk',
     #     disk_name_prefix='')
-    FAKE_ACCOUNT.CreateDiskFromSnapshot(
+    FAKE_ACCOUNT.compute.CreateDiskFromSnapshot(
         FAKE_SNAPSHOT, disk_name='new-forensics-disk')
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
@@ -270,7 +270,7 @@ class TestAccount(unittest.TestCase):
 
     # CreateDiskFromSnapshot(
     #     snapshot=FAKE_SNAPSHOT, disk_name=None, disk_name_prefix='prefix')
-    FAKE_ACCOUNT.CreateDiskFromSnapshot(
+    FAKE_ACCOUNT.compute.CreateDiskFromSnapshot(
         FAKE_SNAPSHOT, disk_name_prefix='prefix')
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
@@ -289,7 +289,7 @@ class TestAccount(unittest.TestCase):
             'name': 'StandardSSD_LRS'
         }
     }
-    FAKE_ACCOUNT.CreateDiskFromSnapshot(
+    FAKE_ACCOUNT.compute.CreateDiskFromSnapshot(
         FAKE_SNAPSHOT, disk_type='StandardSSD_LRS')
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
@@ -301,8 +301,8 @@ class TestAccount(unittest.TestCase):
   @mock.patch('azure.storage.blob._blob_service_client.BlobServiceClient.get_blob_client')
   @mock.patch('azure.storage.blob._blob_service_client.BlobServiceClient.get_container_client')
   @mock.patch('azure.storage.blob._blob_service_client.BlobServiceClient.__init__')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._DeleteStorageAccount')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._CreateStorageAccount')
+  @mock.patch('libcloudforensics.providers.azure.internal.storage.AZStorage.DeleteStorageAccount')
+  @mock.patch('libcloudforensics.providers.azure.internal.storage.AZStorage.CreateStorageAccount')
   @mock.patch('azure.mgmt.compute.v2020_05_01.operations._disks_operations.DisksOperations.create_or_update')
   @typing.no_type_check
   def testCreateDiskFromSnapshotUri(self,
@@ -326,13 +326,13 @@ class TestAccount(unittest.TestCase):
     blob_properties.return_value = mock.Mock(copy=mock.Mock(status='success'))
     mock_delete_storage_account.return_value = None
 
-    disk_from_snapshot_uri = FAKE_ACCOUNT.CreateDiskFromSnapshotURI(
+    disk_from_snapshot_uri = FAKE_ACCOUNT.compute.CreateDiskFromSnapshotURI(
         FAKE_SNAPSHOT, 'fake-snapshot-uri')
     #  hashlib.sha1('/a/b/c/fake-resource-group/fake_snapshot_name'.encode(
     #     'utf-8')).hexdigest()[:23] = bff00b08549ba8b975b2e70
     mock_create_storage_account.assert_called_with(
         'bff00b08549ba8b975b2e70', region='fake-region')
-    self.assertIsInstance(disk_from_snapshot_uri, compute.AZDisk)
+    self.assertIsInstance(disk_from_snapshot_uri, compute.AZComputeDisk)
     self.assertEqual(
         'fake_snapshot_name_f4c186ac_copy', disk_from_snapshot_uri.name)
     mock_create_disk.assert_called_with(
@@ -342,9 +342,9 @@ class TestAccount(unittest.TestCase):
 
   @mock.patch('sshpubkeys.SSHKey.parse')
   @mock.patch('libcloudforensics.scripts.utils.ReadStartupScript')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetInstance')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetInstanceType')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._CreateNetworkInterfaceForVM')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.GetInstance')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute._GetInstanceType')
+  @mock.patch('libcloudforensics.providers.azure.internal.network.AZNetwork.CreateNetworkInterface')
   @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.create_or_update')
   @typing.no_type_check
   def testGetOrCreateAnalysisVm(self,
@@ -361,11 +361,11 @@ class TestAccount(unittest.TestCase):
     mock_script.return_value = ''
     mock_ssh_parse.return_value = None
 
-    vm, created = FAKE_ACCOUNT.GetOrCreateAnalysisVm(
+    vm, created = FAKE_ACCOUNT.compute.GetOrCreateAnalysisVm(
         FAKE_INSTANCE.name, 1, 4, 8192, '')
     mock_get_instance.assert_called_with(FAKE_INSTANCE.name)
     mock_vm.assert_not_called()
-    self.assertIsInstance(vm, compute.AZVirtualMachine)
+    self.assertIsInstance(vm, compute.AZComputeVirtualMachine)
     self.assertEqual('fake-vm-name', vm.name)
     self.assertFalse(created)
 
@@ -374,11 +374,11 @@ class TestAccount(unittest.TestCase):
     # created.
     mock_get_instance.side_effect = RuntimeError()
     mock_vm.return_value.result.return_value = MOCK_ANALYSIS_INSTANCE
-    vm, created = FAKE_ACCOUNT.GetOrCreateAnalysisVm(
+    vm, created = FAKE_ACCOUNT.compute.GetOrCreateAnalysisVm(
         'fake-analysis-vm-name', 1, 4, 8192, '')
     mock_get_instance.assert_called_with('fake-analysis-vm-name')
     mock_vm.assert_called()
-    self.assertIsInstance(vm, compute.AZVirtualMachine)
+    self.assertIsInstance(vm, compute.AZComputeVirtualMachine)
     self.assertEqual('fake-analysis-vm-name', vm.name)
     self.assertTrue(created)
 
@@ -387,23 +387,23 @@ class TestAccount(unittest.TestCase):
   def testListVMSizes(self, mock_list):
     """Test that instance types are correctly listed."""
     mock_list.return_value = MOCK_REQUEST_VM_SIZE
-    available_vms = FAKE_ACCOUNT.ListInstanceTypes()
+    available_vms = FAKE_ACCOUNT.compute.ListInstanceTypes()
     self.assertEqual(1, len(available_vms))
     self.assertEqual('fake-vm-type', available_vms[0]['Name'])
     self.assertEqual(4, available_vms[0]['CPU'])
     self.assertEqual(8192, available_vms[0]['Memory'])
 
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListInstanceTypes')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListInstanceTypes')
   @typing.no_type_check
   def testGetInstanceType(self, mock_list_instance_types):
     """Test that the instance type given a configuration is correct."""
     # pylint: disable=protected-access
     mock_list_instance_types.return_value = MOCK_LIST_VM_SIZES
-    instance_type = FAKE_ACCOUNT._GetInstanceType(4, 8192)
+    instance_type = FAKE_ACCOUNT.compute._GetInstanceType(4, 8192)
     self.assertEqual('fake-vm-type', instance_type)
 
     with self.assertRaises(ValueError):
-      FAKE_ACCOUNT._GetInstanceType(666, 666)
+      FAKE_ACCOUNT.compute._GetInstanceType(666, 666)
     # pylint: enable=protected-access
 
   @mock.patch('azure.mgmt.resource.subscriptions.v2019_11_01.operations._subscriptions_operations.SubscriptionsOperations.list')
@@ -411,7 +411,7 @@ class TestAccount(unittest.TestCase):
   def testListSubscriptionIDs(self, mock_list):
     """Test that subscription IDs are correctly listed"""
     mock_list.return_value = MOCK_LIST_IDS
-    subscription_ids = FAKE_ACCOUNT.ListSubscriptionIDs()
+    subscription_ids = FAKE_ACCOUNT.resource.ListSubscriptionIDs()
     self.assertEqual(2, len(subscription_ids))
     self.assertEqual('fake-subscription-id-1', subscription_ids[0])
 
@@ -423,12 +423,13 @@ class TestAccount(unittest.TestCase):
     # pylint: disable=protected-access
     mock_create.return_value.result.return_value = MOCK_STORAGE_ACCOUNT
     mock_list_keys.return_value = MOCK_LIST_KEYS
-    account_id, account_key = FAKE_ACCOUNT._CreateStorageAccount('fakename')
+    account_id, account_key = FAKE_ACCOUNT.storage.CreateStorageAccount(
+        'fakename')
     self.assertEqual('fakestorageid', account_id)
     self.assertEqual('fake-key-value', account_key)
 
     with self.assertRaises(ValueError) as error:
-      _, _ = FAKE_ACCOUNT._CreateStorageAccount(
+      _, _ = FAKE_ACCOUNT.storage.CreateStorageAccount(
           'fake-non-conform-name')
     # pylint: enable=protected-access
     self.assertEqual('Storage account name fake-non-conform-name does not '
@@ -531,7 +532,7 @@ class TestAZVirtualMachine(unittest.TestCase):
   """Test Azure virtual machine class."""
   # pylint: disable=line-too-long
 
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListDisks')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
   @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')
   @typing.no_type_check
   def testGetBootDisk(self, mock_get_vm, mock_list_disk):
@@ -545,7 +546,7 @@ class TestAZVirtualMachine(unittest.TestCase):
         resource_group_name=FAKE_INSTANCE.resource_group_name)
     self.assertEqual('fake-boot-disk-name', boot_disk.name)
 
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZVirtualMachine.ListDisks')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeVirtualMachine.ListDisks')
   @typing.no_type_check
   def testGetDisk(self, mock_list_disk):
     """Test that a particular disk from an instance is retrieved."""
@@ -559,7 +560,7 @@ class TestAZVirtualMachine(unittest.TestCase):
         'Disk non-existent-disk-name not found in instance: '
         '/a/b/c/fake-resource-group/fake-vm-name', str(error.exception))
 
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListDisks')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
   @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')
   @typing.no_type_check
   def testListDisks(self, mock_get_vm, mock_list_disk):
@@ -622,15 +623,15 @@ class TestForensics(unittest.TestCase):
   """Test Azure forensics file."""
   # pylint: disable=line-too-long, too-many-arguments
 
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.GetDiskType')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeDisk.GetDiskType')
+  @mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZSnapshot.Delete')
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.Snapshot')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetDisk')
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZVirtualMachine.GetBootDisk')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetInstance')
+  @mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.ListSubscriptionIDs')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeSnapshot.Delete')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeDisk.Snapshot')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.GetDisk')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeVirtualMachine.GetBootDisk')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.GetInstance')
   @mock.patch('azure.mgmt.compute.v2020_05_01.operations._disks_operations.DisksOperations.create_or_update')
   @typing.no_type_check
   def testCreateDiskCopy1(self,
@@ -668,18 +669,18 @@ class TestForensics(unittest.TestCase):
     mock_get_instance.assert_called_with('fake-vm-name')
     mock_get_boot_disk.assert_called_once()
     mock_get_disk.assert_not_called()
-    self.assertIsInstance(disk_copy, compute.AZDisk)
+    self.assertIsInstance(disk_copy, compute.AZComputeDisk)
     self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_copy.name)
 
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.GetDiskType')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeDisk.GetDiskType')
+  @mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZSnapshot.Delete')
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.Snapshot')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetDisk')
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZVirtualMachine.GetBootDisk')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.GetInstance')
+  @mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.ListSubscriptionIDs')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeSnapshot.Delete')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeDisk.Snapshot')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.GetDisk')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeVirtualMachine.GetBootDisk')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.GetInstance')
   @mock.patch('azure.mgmt.compute.v2020_05_01.operations._disks_operations.DisksOperations.create_or_update')
   @typing.no_type_check
   def testCreateDiskCopy2(self,
@@ -716,15 +717,15 @@ class TestForensics(unittest.TestCase):
     mock_get_boot_disk.assert_not_called()
     mock_get_disk.assert_called_once()
     mock_get_disk.assert_called_with('fake-disk-name')
-    self.assertIsInstance(disk_copy, compute.AZDisk)
+    self.assertIsInstance(disk_copy, compute.AZComputeDisk)
     self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_copy.name)
 
-  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZDisk.GetDiskType')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount._GetOrCreateResourceGroup')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZComputeDisk.GetDiskType')
+  @mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.GetOrCreateResourceGroup')
   @mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListSubscriptionIDs')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListDisks')
-  @mock.patch('libcloudforensics.providers.azure.internal.account.AZAccount.ListInstances')
+  @mock.patch('libcloudforensics.providers.azure.internal.resource.AZResource.ListSubscriptionIDs')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
+  @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListInstances')
   @typing.no_type_check
   def testCreateDiskCopy3(self,
                           mock_list_instances,

--- a/tests/providers/azure/azure_test.py
+++ b/tests/providers/azure/azure_test.py
@@ -23,6 +23,9 @@ from azure.mgmt.compute.v2020_05_01 import models  # pylint: disable=import-erro
 from libcloudforensics.providers.azure.internal import account, compute, common, monitoring  # pylint:disable=line-too-long
 from libcloudforensics.providers.azure import forensics
 
+RESOURCE_ID_PREFIX = ('/subscriptions/sub/resourceGroups/fake-resource-group'
+                      '/providers/Microsoft.Compute/type/')
+
 # pylint: disable=line-too-long
 with mock.patch('libcloudforensics.providers.azure.internal.common.GetCredentials') as mock_creds:
   mock_creds.return_value = ('fake-subscription-id', mock.Mock())
@@ -36,7 +39,7 @@ with mock.patch('libcloudforensics.providers.azure.internal.common.GetCredential
 
 FAKE_INSTANCE = compute.AZComputeVirtualMachine(
     FAKE_ACCOUNT,
-    '/a/b/c/fake-resource-group/fake-vm-name',
+    RESOURCE_ID_PREFIX + 'fake-vm-name',
     'fake-vm-name',
     'fake-region',
     ['fake-zone']
@@ -44,7 +47,7 @@ FAKE_INSTANCE = compute.AZComputeVirtualMachine(
 
 FAKE_DISK = compute.AZComputeDisk(
     FAKE_ACCOUNT,
-    '/a/b/c/fake-resource-group/fake-disk-name',
+    RESOURCE_ID_PREFIX + 'fake-disk-name',
     'fake-disk-name',
     'fake-region',
     ['fake-zone']
@@ -52,7 +55,7 @@ FAKE_DISK = compute.AZComputeDisk(
 
 FAKE_BOOT_DISK = compute.AZComputeDisk(
     FAKE_ACCOUNT,
-    '/a/b/c/fake-resource-group/fake-boot-disk-name',
+    RESOURCE_ID_PREFIX + 'fake-boot-disk-name',
     'fake-boot-disk-name',
     'fake-region',
     ['fake-zone']
@@ -60,7 +63,7 @@ FAKE_BOOT_DISK = compute.AZComputeDisk(
 
 FAKE_SNAPSHOT = compute.AZComputeSnapshot(
     FAKE_ACCOUNT,
-    '/a/b/c/fake-resource-group/fake_snapshot_name',
+    RESOURCE_ID_PREFIX + 'fake_snapshot_name',
     'fake_snapshot_name',
     'fake-region',
     FAKE_DISK
@@ -69,7 +72,7 @@ FAKE_SNAPSHOT = compute.AZComputeSnapshot(
 FAKE_MONITORING = monitoring.AZMonitoring(FAKE_ACCOUNT)
 
 MOCK_INSTANCE = mock.Mock(
-    id='/a/b/c/fake-resource-group/fake-vm-name',
+    id=RESOURCE_ID_PREFIX + 'fake-vm-name',
     location='fake-region',
     zones=['fake-zone']
 )
@@ -82,21 +85,21 @@ MOCK_LIST_INSTANCES = {
 }
 
 MOCK_DISK = mock.Mock(
-    id='/a/b/c/fake-resource-group/fake-disk-name',
+    id=RESOURCE_ID_PREFIX + 'fake-disk-name',
     location='fake-region',
     zones=['fake-zone']
 )
 MOCK_DISK.name = 'fake-disk-name'
 
 MOCK_BOOT_DISK = mock.Mock(
-    id='/a/b/c/fake-resource-group/fake-boot-disk-name',
+    id=RESOURCE_ID_PREFIX + 'fake-boot-disk-name',
     location='fake-region',
     zones=['fake-zone']
 )
 MOCK_BOOT_DISK.name = 'fake-boot-disk-name'
 
 MOCK_DISK_COPY = mock.Mock(
-    id='/a/b/c/fake-resource-group/fake_snapshot_name_f4c186ac_copy',
+    id=RESOURCE_ID_PREFIX + 'fake_snapshot_name_f4c186ac_copy',
     location='fake-region',
     zones=['fake-zone']
 )
@@ -121,7 +124,7 @@ MOCK_LIST_VM_SIZES = [{
 }]
 
 MOCK_ANALYSIS_INSTANCE = mock.Mock(
-    id='/a/b/c/fake-resource-group/fake-analysis-vm-name',
+    id=RESOURCE_ID_PREFIX + 'fake-analysis-vm-name',
     location='fake-region',
     zones=['fake-zone']
 )
@@ -174,7 +177,8 @@ class TestAccount(unittest.TestCase):
     instance = instances['fake-vm-name']
     self.assertEqual('fake-vm-name', instance.name)
     self.assertEqual(
-        '/a/b/c/fake-resource-group/fake-vm-name', instance.resource_id)
+        '/subscriptions/sub/resourceGroups/fake-resource-group'
+        '/providers/Microsoft.Compute/type/fake-vm-name', instance.resource_id)
     self.assertEqual('fake-resource-group', instance.resource_group_name)
     self.assertEqual('fake-region', instance.region)
     self.assertEqual(['fake-zone'], instance.zones)
@@ -200,7 +204,8 @@ class TestAccount(unittest.TestCase):
     disk = disks['fake-disk-name']
     self.assertEqual('fake-disk-name', disk.name)
     self.assertEqual(
-        '/a/b/c/fake-resource-group/fake-disk-name', disk.resource_id)
+        '/subscriptions/sub/resourceGroups/fake-resource-group'
+        '/providers/Microsoft.Compute/type/fake-disk-name', disk.resource_id)
     self.assertEqual('fake-resource-group', disk.resource_group_name)
     self.assertEqual('fake-region', disk.region)
     self.assertEqual(['fake-zone'], disk.zones)
@@ -221,7 +226,8 @@ class TestAccount(unittest.TestCase):
     instance = FAKE_ACCOUNT.compute.GetInstance('fake-vm-name')
     self.assertEqual('fake-vm-name', instance.name)
     self.assertEqual(
-        '/a/b/c/fake-resource-group/fake-vm-name', instance.resource_id)
+        '/subscriptions/sub/resourceGroups/fake-resource-group'
+        '/providers/Microsoft.Compute/type/fake-vm-name', instance.resource_id)
     self.assertEqual('fake-resource-group', instance.resource_group_name)
     self.assertEqual('fake-region', instance.region)
     self.assertEqual(['fake-zone'], instance.zones)
@@ -234,7 +240,8 @@ class TestAccount(unittest.TestCase):
     disk = FAKE_ACCOUNT.compute.GetDisk('fake-disk-name')
     self.assertEqual('fake-disk-name', disk.name)
     self.assertEqual(
-        '/a/b/c/fake-resource-group/fake-disk-name', disk.resource_id)
+        '/subscriptions/sub/resourceGroups/fake-resource-group'
+        '/providers/Microsoft.Compute/type/fake-disk-name', disk.resource_id)
     self.assertEqual('fake-resource-group', disk.resource_group_name)
     self.assertEqual('fake-region', disk.region)
     self.assertEqual(['fake-zone'], disk.zones)
@@ -254,7 +261,7 @@ class TestAccount(unittest.TestCase):
         'fake_snapshot_name_f4c186ac_copy', disk_from_snapshot.name)
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
-        'fake_snapshot_name_f4c186ac_copy',
+        'fake_snapshot_name_c4a46ad7_copy',
         mock.ANY)
 
     # CreateDiskFromSnapshot(
@@ -274,7 +281,7 @@ class TestAccount(unittest.TestCase):
         FAKE_SNAPSHOT, disk_name_prefix='prefix')
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
-        'prefix_fake_snapshot_name_f4c186ac_copy',
+        'prefix_fake_snapshot_name_c4a46ad7_copy',
         mock.ANY)
 
     # CreateDiskFromSnapshot(
@@ -282,7 +289,9 @@ class TestAccount(unittest.TestCase):
     expected_args = {
         'location': 'fake-region',
         'creation_data': {
-            'sourceResourceId': '/a/b/c/fake-resource-group/fake_snapshot_name',
+            'sourceResourceId': '/subscriptions/sub/resourceGroups/'
+                                'fake-resource-group/providers/'
+                                'Microsoft.Compute/type/fake_snapshot_name',
             'create_option': models.DiskCreateOption.copy
         },
         'sku': {
@@ -293,7 +302,7 @@ class TestAccount(unittest.TestCase):
         FAKE_SNAPSHOT, disk_type='StandardSSD_LRS')
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
-        'fake_snapshot_name_f4c186ac_copy',
+        'fake_snapshot_name_c4a46ad7_copy',
         expected_args)
 
   @mock.patch('azure.storage.blob._container_client.ContainerClient.create_container')
@@ -329,15 +338,15 @@ class TestAccount(unittest.TestCase):
     disk_from_snapshot_uri = FAKE_ACCOUNT.compute.CreateDiskFromSnapshotURI(
         FAKE_SNAPSHOT, 'fake-snapshot-uri')
     #  hashlib.sha1('/a/b/c/fake-resource-group/fake_snapshot_name'.encode(
-    #     'utf-8')).hexdigest()[:23] = bff00b08549ba8b975b2e70
+    #     'utf-8')).hexdigest()[:23] = 97d1e8cfe4cf4d573fea2b5
     mock_create_storage_account.assert_called_with(
-        'bff00b08549ba8b975b2e70', region='fake-region')
+        '97d1e8cfe4cf4d573fea2b5', region='fake-region')
     self.assertIsInstance(disk_from_snapshot_uri, compute.AZComputeDisk)
     self.assertEqual(
         'fake_snapshot_name_f4c186ac_copy', disk_from_snapshot_uri.name)
     mock_create_disk.assert_called_with(
         FAKE_SNAPSHOT.resource_group_name,
-        'fake_snapshot_name_f4c186ac_copy',
+        'fake_snapshot_name_c4a46ad7_copy',
         mock.ANY)
 
   @mock.patch('sshpubkeys.SSHKey.parse')
@@ -447,11 +456,11 @@ class TestCommon(unittest.TestCase):
         i.e., it must be between 1 and 80 chars and be within [a-zA-Z0-9].
     """
     disk_name = common.GenerateDiskName(FAKE_SNAPSHOT)
-    self.assertEqual('fake_snapshot_name_f4c186ac_copy', disk_name)
+    self.assertEqual('fake_snapshot_name_c4a46ad7_copy', disk_name)
 
     disk_name = common.GenerateDiskName(
         FAKE_SNAPSHOT, disk_name_prefix='prefix')
-    self.assertEqual('prefix_fake_snapshot_name_f4c186ac_copy', disk_name)
+    self.assertEqual('prefix_fake_snapshot_name_c4a46ad7_copy', disk_name)
 
   @mock.patch('msrestazure.azure_active_directory.ServicePrincipalCredentials.__init__')
   @typing.no_type_check
@@ -558,7 +567,8 @@ class TestAZVirtualMachine(unittest.TestCase):
       FAKE_INSTANCE.GetDisk('non-existent-disk-name')
     self.assertEqual(
         'Disk non-existent-disk-name not found in instance: '
-        '/a/b/c/fake-resource-group/fake-vm-name', str(error.exception))
+        '/subscriptions/sub/resourceGroups/fake-resource-group'
+        '/providers/Microsoft.Compute/type/fake-vm-name', str(error.exception))
 
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
   @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')

--- a/tools/az_cli.py
+++ b/tools/az_cli.py
@@ -38,7 +38,7 @@ def ListInstances(args: 'argparse.Namespace') -> None:
   """
 
   az_account = account.AZAccount(args.default_resource_group_name)
-  instances = az_account.ListInstances(
+  instances = az_account.compute.ListInstances(
       resource_group_name=args.resource_group_name)
 
   logger.info('Instances found:')
@@ -55,7 +55,8 @@ def ListDisks(args: 'argparse.Namespace') -> None:
   """
 
   az_account = account.AZAccount(args.default_resource_group_name)
-  disks = az_account.ListDisks(resource_group_name=args.resource_group_name)
+  disks = az_account.compute.ListDisks(
+      resource_group_name=args.resource_group_name)
 
   logger.info('Disks found:')
   for disk in disks:


### PR DESCRIPTION
Closes #224. 

Together with #225, this PR harmonizes the structure under which cloud provider functionality are implemented, following GCP's module organisation. `account.py` now only contains references to modules (compute, networking, monitoring, storage, etc). 

This breaks down the code a little more and separate functionality better.

Unit tests, end to end tests and CLI files are updated as well to use the new structure.

Signed-off-by: Theo Giovanna <gtheo@google.com>