### PR TITLE
Fix try catch block

### DIFF
--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -411,7 +411,7 @@ class AZCompute:
       if instance:
         created = False
         return instance, created
-    except RuntimeError:
+    except errors.ResourceNotFoundError:
       pass
 
     # Validate SSH public key format

--- a/tests/providers/azure/internal/test_compute.py
+++ b/tests/providers/azure/internal/test_compute.py
@@ -249,10 +249,10 @@ class AZComputeTest(unittest.TestCase):
     self.assertEqual('fake-vm-name', vm.name)
     self.assertFalse(created)
 
-    # We mock the GetInstance() call to throw a RuntimeError to mimic
+    # We mock the GetInstance() call to throw a ResourceNotFoundError to mimic
     # an instance that wasn't found. This should trigger a vm to be
     # created.
-    mock_get_instance.side_effect = RuntimeError()
+    mock_get_instance.side_effect = errors.ResourceNotFoundError('', __name__)
     mock_vm.return_value.result.return_value = azure_mocks.MOCK_ANALYSIS_INSTANCE
     vm, created = azure_mocks.FAKE_ACCOUNT.compute.GetOrCreateAnalysisVm(
         'fake-analysis-vm-name', 1, 4, 8192, '')


### PR DESCRIPTION
A small bug introduced by #223, where the `try/catch` block was not updated to catch the appropriate error.

Signed-off-by: Theo Giovanna <gtheo@google.com>