### PR TITLE
Update codebase to latest pylint version

### DIFF
--- a/libcloudforensics/errors.py
+++ b/libcloudforensics/errors.py
@@ -34,7 +34,7 @@ class LCFError(Exception):
       message (str): The error message.
       name (str): The name of the module that generated the error.
     """
-    super(LCFError, self).__init__(message)
+    super().__init__(message)
     self.message = message
     self.name = name
     logging_utils.SetUpLogger(self.name)

--- a/libcloudforensics/logging_utils.py
+++ b/libcloudforensics/logging_utils.py
@@ -82,7 +82,7 @@ class Formatter(logging.Formatter):
       if random_color:
         color = random.choice(COLOR_SEQS)
       kwargs['fmt'] = LOG_FORMAT.format(BOLD, RESET_SEQ, color=color)
-    super(Formatter, self).__init__(**kwargs)
+    super().__init__(**kwargs)
 
   def format(self, record: logging.LogRecord) -> str:
     """Hooks the native format method and colorizes messages if needed.
@@ -99,7 +99,7 @@ class Formatter(logging.Formatter):
       if loglevel_color:
         message = loglevel_color + message + RESET_SEQ
       record.msg = message
-    return super(Formatter, self).format(record)
+    return super().format(record)
 
 
 def SetUpLogger(name: str) -> None:

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -188,7 +188,7 @@ def CreateVolumeCopy(zone: str,
   except (errors.LCFError, RuntimeError) as exception:
     raise errors.ResourceCreationError(
         'Copying volume {0:s}: {1!s}'.format(
-            (volume_id or instance_id), exception), __name__)
+            (volume_id or instance_id), exception), __name__) from exception
 
   return new_volume
 

--- a/libcloudforensics/providers/aws/internal/common.py
+++ b/libcloudforensics/providers/aws/internal/common.py
@@ -119,7 +119,7 @@ def ExecuteRequest(client: 'botocore.client.EC2',
       response = request(**kwargs)
     except client.exceptions.ClientError as exception:
       raise RuntimeError('Could not process request: {0:s}'.format(
-          str(exception)))
+          str(exception))) from exception
     responses.append(response)
     next_token = response.get('NextToken')
     if not next_token:

--- a/libcloudforensics/providers/aws/internal/ebs.py
+++ b/libcloudforensics/providers/aws/internal/ebs.py
@@ -98,11 +98,11 @@ class AWSVolume(AWSElasticBlockStore):
           volume when it is attached to an instance, if applicable.
     """
 
-    super(AWSVolume, self).__init__(aws_account,
-                                    region,
-                                    availability_zone,
-                                    encrypted,
-                                    name)
+    super().__init__(aws_account,
+                     region,
+                     availability_zone,
+                     encrypted,
+                     name)
     self.volume_id = volume_id
     self.device_name = device_name
 
@@ -148,7 +148,7 @@ class AWSVolume(AWSElasticBlockStore):
             botocore.exceptions.WaiterError) as exception:
       raise errors.ResourceCreationError(
           'Could not create snapshot for volume {0:s}: {1:s}'.format(
-              self.volume_id, str(exception)), __name__)
+              self.volume_id, str(exception)), __name__) from exception
 
     return AWSSnapshot(snapshot_id,
                        self.aws_account,
@@ -169,7 +169,7 @@ class AWSVolume(AWSElasticBlockStore):
     except client.exceptions.ClientError as exception:
       raise errors.ResourceDeletionError(
           'Could not delete volume {0:s}: {1:s}'.format(
-              self.volume_id, str(exception)), __name__)
+              self.volume_id, str(exception)), __name__) from exception
 
   def GetVolumeType(self) -> str:
     """Return the volume type.
@@ -214,11 +214,11 @@ class AWSSnapshot(AWSElasticBlockStore):
       name (str): Optional. The name tag of the snapshot, if existing.
     """
 
-    super(AWSSnapshot, self).__init__(aws_account,
-                                      region,
-                                      availability_zone,
-                                      volume.encrypted,
-                                      name)
+    super().__init__(aws_account,
+                     region,
+                     availability_zone,
+                     volume.encrypted,
+                     name)
     self.snapshot_id = snapshot_id
     self.volume = volume
 
@@ -263,7 +263,7 @@ class AWSSnapshot(AWSElasticBlockStore):
     except client.exceptions.ClientError as exception:
       raise errors.ResourceCreationError(
           'Could not copy snapshot {0:s}: {1:s}'.format(
-              self.snapshot_id, str(exception)), __name__)
+              self.snapshot_id, str(exception)), __name__) from exception
 
     snapshot_copy = AWSSnapshot(
         # The response contains the new snapshot ID
@@ -300,7 +300,7 @@ class AWSSnapshot(AWSElasticBlockStore):
     except client.exceptions.ClientError as exception:
       raise errors.ResourceDeletionError(
           'Could not delete snapshot {0:s}: {1:s}'.format(
-              self.snapshot_id, str(exception)), __name__)
+              self.snapshot_id, str(exception)), __name__) from exception
 
   def ShareWithAWSAccount(self, aws_account_id: str) -> None:
     """Share the snapshot with another AWS account ID.
@@ -548,7 +548,7 @@ class EBS:
             botocore.exceptions.WaiterError) as exception:
       raise errors.ResourceCreationError(
           'Could not create volume {0:s} from snapshot {1:s}: {2!s}'.format(
-              volume_name, snapshot.name, exception), __name__)
+              volume_name, snapshot.name, exception), __name__) from exception
 
     zone = volume['AvailabilityZone']
     encrypted = volume['Encrypted']

--- a/libcloudforensics/providers/aws/internal/ec2.py
+++ b/libcloudforensics/providers/aws/internal/ec2.py
@@ -141,7 +141,7 @@ class AWSInstance:
                            VolumeId=volume.volume_id)
     except client.exceptions.ClientError as exception:
       raise RuntimeError('Could not attach volume {0:s}: {1:s}'.format(
-          volume.volume_id, str(exception)))
+          volume.volume_id, str(exception))) from exception
 
     volume.device_name = device_name
 
@@ -325,7 +325,7 @@ class EC2:
       images = client.describe_images(
           Filters=qfilter)  # type: Dict[str, List[Dict[str, Any]]]
     except client.exceptions.ClientError as exception:
-      raise RuntimeError(str(exception))
+      raise RuntimeError(str(exception)) from exception
 
     return images['Images']
 
@@ -421,7 +421,7 @@ class EC2:
             botocore.exceptions.WaiterError) as exception:
       raise errors.ResourceCreationError(
           'Could not create instance {0:s}: {1!s}'.format(vm_name, exception),
-          __name__)
+          __name__) from exception
 
     instance = AWSInstance(self.aws_account,
                            instance_id,
@@ -456,7 +456,7 @@ class EC2:
     except client.exceptions.ClientError as exception:
       raise errors.ResourceNotFoundError(
           'Could not find image information for AMI {0:s}: {1!s}'.format(
-              ami, exception), __name__)
+              ami, exception), __name__) from exception
 
     # If the call to describe_images was successful, then the API's response
     # is expected to contain at least one image and its corresponding block
@@ -501,6 +501,7 @@ class EC2:
       key = client.create_key_pair(KeyName=key_name)
     except client.exceptions.ClientError as exception:
       raise errors.ResourceCreationError(
-          'Could not create SSH key pair: {0!s}'.format(exception), __name__)
+          'Could not create SSH key pair: {0!s}'.format(
+              exception), __name__) from exception
     # If the call was successful, the response contains key information
     return key['KeyName'], key['KeyMaterial']

--- a/libcloudforensics/providers/aws/internal/kms.py
+++ b/libcloudforensics/providers/aws/internal/kms.py
@@ -53,7 +53,8 @@ class KMS:
       kms_key = client.create_key()
     except client.exceptions.ClientError as exception:
       raise errors.ResourceCreationError(
-          'Could not create KMS key: {0!s}'.format(exception), __name__)
+          'Could not create KMS key: {0!s}'.format(
+              exception), __name__) from exception
 
     # The response contains the key ID
     key_id = kms_key['KeyMetadata']['KeyId']  # type: str
@@ -100,7 +101,7 @@ class KMS:
           KeyId=kms_key_id, PolicyName='default', Policy=json.dumps(policy))
     except client.exceptions.ClientError as exception:
       raise RuntimeError('Could not share KMS key {0:s}: {1:s}'.format(
-          kms_key_id, str(exception)))
+          kms_key_id, str(exception))) from exception
 
   def DeleteKMSKey(self, kms_key_id: Optional[str] = None) -> None:
     """Delete a KMS key.
@@ -124,4 +125,4 @@ class KMS:
     except client.exceptions.ClientError as exception:
       raise errors.ResourceDeletionError(
           'Could not schedule the KMS key {0:s} for deletion {1!s}'.format(
-              exception, kms_key_id), __name__)
+              exception, kms_key_id), __name__) from exception

--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -125,7 +125,7 @@ def CreateDiskCopy(
         disk_to_copy.name, new_disk.name))
   except (errors.LCFError, RuntimeError) as exception:
     raise errors.ResourceCreationError('Cannot copy disk "{0:s}": {1!s}'.format(
-        str(disk_name), exception), __name__)
+        str(disk_name), exception), __name__) from exception
 
   return new_disk
 

--- a/libcloudforensics/providers/azure/internal/common.py
+++ b/libcloudforensics/providers/azure/internal/common.py
@@ -122,7 +122,7 @@ def GetCredentials(profile_name: Optional[str] = None
     except ValueError as exception:
       raise errors.InvalidFileFormatError(
           'Could not decode JSON file. Please verify the file format:'
-          ' {0!s}'.format(exception), __name__)
+          ' {0!s}'.format(exception), __name__) from exception
     if not account_info:
       raise errors.CredentialsConfigurationError(
           'Profile name {0:s} not found in credentials file {1:s}'.format(

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -236,7 +236,7 @@ class AZCompute:
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceCreationError(
           'Could not create disk from snapshot {0:s}: {1!s}'.format(
-              snapshot.resource_id, exception), __name__)
+              snapshot.resource_id, exception), __name__) from exception
 
     return AZComputeDisk(self.az_account,
                          disk.id,
@@ -355,7 +355,7 @@ class AZCompute:
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceCreationError(
           'Could not create disk from URI {0:s}: {1!s}'.format(
-              snapshot_uri, exception), __name__)
+              snapshot_uri, exception), __name__) from exception
 
     # Cleanup the temporary account storage
     self.az_account.storage.DeleteStorageAccount(storage_account_name)
@@ -419,7 +419,7 @@ class AZCompute:
       sshpubkeys.SSHKey(ssh_public_key, strict=True).parse()
     except sshpubkeys.InvalidKeyError as exception:
       raise RuntimeError('The provided public SSH key is invalid: '
-                         '{0:s}'.format(str(exception)))
+                         '{0:s}'.format(str(exception))) from exception
 
     instance_type = self._GetInstanceType(cpu_cores, memory_in_mb)
     startup_script = utils.ReadStartupScript()
@@ -490,7 +490,7 @@ class AZCompute:
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceCreationError(
           'Could not create instance {0:s}: {1!s}'.format(vm_name, exception),
-          __name__)
+          __name__) from exception
 
     instance = AZComputeVirtualMachine(self.az_account,
                                        vm.id,
@@ -569,11 +569,11 @@ class AZComputeVirtualMachine(compute_base_resource.AZComputeResource):
       zones (List[str]): Optional. Availability zones within the region where
           the virtual machine is located / replicated.
     """
-    super(AZComputeVirtualMachine, self).__init__(az_account,
-                                                  resource_id,
-                                                  name,
-                                                  region,
-                                                  zones=zones)
+    super().__init__(az_account,
+                     resource_id,
+                     name,
+                     region,
+                     zones=zones)
 
   def GetBootDisk(self) -> 'AZComputeDisk':
     """Get the instance's boot disk.
@@ -661,8 +661,9 @@ class AZComputeVirtualMachine(compute_base_resource.AZComputeResource):
       while not request.done():
         sleep(5)  # Wait 5 seconds before checking vm status again
     except azure_exceptions.CloudError as exception:
-      raise RuntimeError('Could not attach disk {0:s} to instance {1:s}: '
-                         '{2:s}'.format(disk.name, self.name, str(exception)))
+      raise RuntimeError(
+          'Could not attach disk {0:s} to instance {1:s}: {2:s}'.format(
+              disk.name, self.name, str(exception))) from exception
 
 
 class AZComputeDisk(compute_base_resource.AZComputeResource):
@@ -684,11 +685,11 @@ class AZComputeDisk(compute_base_resource.AZComputeResource):
       zones (List[str]): Optional. Availability zone within the region where
           the disk is located.
     """
-    super(AZComputeDisk, self).__init__(az_account,
-                                        resource_id,
-                                        name,
-                                        region,
-                                        zones=zones)
+    super().__init__(az_account,
+                     resource_id,
+                     name,
+                     region,
+                     zones=zones)
 
   def Snapshot(self,
                snapshot_name: Optional[str] = None,
@@ -742,7 +743,7 @@ class AZComputeDisk(compute_base_resource.AZComputeResource):
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceCreationError(
           'Could not create snapshot for disk {0:s}: {1!s}'.format(
-              self.resource_id, exception), __name__)
+              self.resource_id, exception), __name__) from exception
 
     return AZComputeSnapshot(self.az_account,
                              snapshot.id,
@@ -784,10 +785,10 @@ class AZComputeSnapshot(compute_base_resource.AZComputeResource):
       region (str): The region in which the snapshot is located.
       source_disk (AZComputeDisk): The disk from which the snapshot was taken.
     """
-    super(AZComputeSnapshot, self).__init__(az_account,
-                                            resource_id,
-                                            name,
-                                            region)
+    super().__init__(az_account,
+                     resource_id,
+                     name,
+                     region)
 
     self.disk = source_disk
 
@@ -808,7 +809,7 @@ class AZComputeSnapshot(compute_base_resource.AZComputeResource):
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceDeletionError(
           'Could not delete snapshot {0:s}: {1!s}'.format(
-              self.resource_id, exception), __name__)
+              self.resource_id, exception), __name__) from exception
 
   def GrantAccessAndGetURI(self) -> str:
     """Grant access to a snapshot and return its access URI.

--- a/libcloudforensics/providers/azure/internal/monitoring.py
+++ b/libcloudforensics/providers/azure/internal/monitoring.py
@@ -64,11 +64,12 @@ class AZMonitoring:
     try:
       return [metric.name.value for metric
               in self.monitoring_client.metric_definitions.list(resource_id)]
-    except models.ErrorResponseException:
-      raise RuntimeError('Could not fetch metrics for resource {0:s}. Please '
-                         'make sure you specified the full resource ID url, '
-                         'i.e. /subscriptions/<>/resourceGroups/<>/providers'
-                         '/<>/<>/yourResourceName'.format(resource_id))
+    except models.ErrorResponseException as exception:
+      raise RuntimeError(
+          'Could not fetch metrics for resource {0:s}. Please make sure you '
+          'specified the full resource ID url, i.e. /subscriptions/<>/'
+          'resourceGroups/<>/providers/<>/<>/yourResourceName'.format(
+              resource_id)) from exception
 
   def GetMetricsForResource(
       self,
@@ -116,12 +117,12 @@ class AZMonitoring:
     try:
       metrics_data = self.monitoring_client.metrics.list(
           resource_id, filter=qfilter, **kwargs)
-    except models.ErrorResponseException:
+    except models.ErrorResponseException as exception:
       raise RuntimeError(
           'Could not fetch metrics {0:s} for resource {1:s}.  Please make '
           'sure you specified the full resource ID  url, i.e. /subscriptions/'
           '<>/resourceGroups/<>/providers/<>/<>/yourResourceName'.format(
-              metrics, resource_id))
+              metrics, resource_id)) from exception
     results = {}  # type: Dict[str, Dict[str, str]]
     for metric in metrics_data.value:
       values = {}

--- a/libcloudforensics/providers/azure/internal/network.py
+++ b/libcloudforensics/providers/azure/internal/network.py
@@ -85,7 +85,7 @@ class AZNetwork:
       if 'ResourceNotFound' not in exception.error.error:
         raise errors.ResourceCreationError(
             'Could not create network interface: {0!s}'.format(exception),
-            __name__)
+            __name__) from exception
       # NIC doesn't exist, ignore the error and create it
 
     # pylint: disable=unbalanced-tuple-unpacking
@@ -115,7 +115,7 @@ class AZNetwork:
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceCreationError(
           'Could not create network interface: {0!s}'.format(exception),
-          __name__)
+          __name__) from exception
 
     network_interface_id = request.result().id  # type: str
     return network_interface_id
@@ -207,5 +207,5 @@ class AZNetwork:
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceCreationError(
           'Could not create network interface elements: {0!s}'.format(
-              exception), __name__)
+              exception), __name__) from exception
     return tuple(result)

--- a/libcloudforensics/providers/azure/internal/storage.py
+++ b/libcloudforensics/providers/azure/internal/storage.py
@@ -126,4 +126,4 @@ class AZStorage:
     except azure_exceptions.CloudError as exception:
       raise errors.ResourceDeletionError(
           'Could not delete account storage {0:s}: {1:s}'.format(
-              storage_account_name, str(exception)), __name__)
+              storage_account_name, str(exception)), __name__) from exception

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -95,21 +95,21 @@ def CreateDiskCopy(
     raise errors.CredentialsConfigurationError(
         'Something is wrong with your Application Default Credentials. Try '
         'running: $ gcloud auth application-default login: {0!s}'.format(
-            exception), __name__)
+            exception), __name__) from exception
   except HttpError as exception:
     if exception.resp.status == 403:
       raise errors.CredentialsConfigurationError(
           'Make sure you have the appropriate permissions on the project',
-          __name__)
+          __name__) from exception
     if exception.resp.status == 404:
       raise errors.ResourceNotFoundError(
           'GCP resource not found. Maybe a typo in the project / instance / '
-          'disk name?', __name__)
-    raise RuntimeError(exception)
+          'disk name?', __name__) from exception
+    raise RuntimeError(exception) from exception
   except RuntimeError as exception:
     raise errors.ResourceCreationError(
         'Cannot copy disk "{0:s}": {1!s}'.format(disk_name, exception),
-        __name__)
+        __name__) from exception
 
   return new_disk
 

--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -131,7 +131,7 @@ def CreateService(service_name: str,
     raise errors.CredentialsConfigurationError(
         'Could not get application default credentials. Have you run $ gcloud '
         'auth application-default login?: {0!s}'.format_map(exception),
-        __name__)
+        __name__) from exception
 
   service_built = False
   for retry in range(RETRY_MAX):
@@ -270,7 +270,7 @@ def ExecuteRequest(client: 'googleapiclient.discovery.Resource',
       raise errors.CredentialsConfigurationError(
           ': {0!s}. Something is wrong with your Application Default '
           'Credentials. Try running: $ gcloud auth application-default '
-          'login'.format(exception), __name__)
+          'login'.format(exception), __name__) from exception
     responses.append(response)
     next_token = response.get('nextPageToken')
     if not next_token:

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -55,7 +55,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     self.default_zone = default_zone or 'us-central1-f'
     self._instances = {}  # type: Dict[str, GoogleComputeInstance]
     self._disks = {}  # type: Dict[str, GoogleComputeDisk]
-    super(GoogleCloudCompute, self).__init__(self.project_id)
+    super().__init__(self.project_id)
 
   def Instances(self,
                 refresh: bool = True
@@ -229,10 +229,10 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
       if exception.resp.status == 409:
         raise errors.ResourceCreationError(
             'Disk {0:s} already exists: {1!s}'.format(disk_name, exception),
-            __name__)
+            __name__) from exception
       raise errors.ResourceCreationError(
           'Unknown error occurred when creating disk from Snapshot:'
-          ' {0!s}'.format(exception), __name__)
+          ' {0!s}'.format(exception), __name__) from exception
     self.BlockOperation(response, zone=self.default_zone)
     return GoogleComputeDisk(
         project_id=self.project_id,
@@ -942,8 +942,7 @@ class GoogleComputeSnapshot(compute_base_resource.GoogleComputeBaseResource):
       name (str): Name of the Snapshot.
     """
 
-    super(GoogleComputeSnapshot, self).__init__(
-        project_id=disk.project_id, zone=disk.zone, name=name)
+    super().__init__(project_id=disk.project_id, zone=disk.zone, name=name)
     self.disk = disk
 
   def GetOperation(self) -> Dict[str, Any]:

--- a/libcloudforensics/providers/gcp/internal/compute_base_resource.py
+++ b/libcloudforensics/providers/gcp/internal/compute_base_resource.py
@@ -51,7 +51,7 @@ class GoogleComputeBaseResource(common.GoogleCloudComputeClient):
     self.labels = labels
     self._data = {}  # type: Dict[str, Any]
     self.project_id = project_id  # type: str
-    super(GoogleComputeBaseResource, self).__init__(self.project_id)
+    super().__init__(self.project_id)
 
   def FormatLogMessage(self, message: str) -> str:
     """Format log messages with project specific information.

--- a/libcloudforensics/providers/gcp/internal/function.py
+++ b/libcloudforensics/providers/gcp/internal/function.py
@@ -88,11 +88,11 @@ class GoogleCloudFunction:
 
     try:
       json_args = json.dumps(args)
-    except TypeError as e:
+    except TypeError as exception:
       error_msg = (
           'Cloud function args [{0:s}] could not be serialized:'
-          ' {1!s}').format(str(args), e)
-      raise RuntimeError(error_msg)
+          ' {1!s}').format(str(args), exception)
+      raise RuntimeError(error_msg) from exception
 
     function_path = 'projects/{0:s}/locations/{1:s}/functions/{2:s}'.format(
         self.project_id, region, function_name)
@@ -105,9 +105,9 @@ class GoogleCloudFunction:
           name=function_path, body={
               'data': json_args
           }).execute()  # type: Dict[str, Any]
-    except (HttpError, ssl.SSLError) as e:
+    except (HttpError, ssl.SSLError) as exception:
       error_msg = 'Cloud function [{0:s}] call failed: {1!s}'.format(
-          function_name, e)
-      raise RuntimeError(error_msg)
+          function_name, exception)
+      raise RuntimeError(error_msg) from exception
 
     return function_return

--- a/libcloudforensics/scripts/utils.py
+++ b/libcloudforensics/scripts/utils.py
@@ -47,4 +47,4 @@ def ReadStartupScript() -> str:
   except OSError as exception:
     raise OSError(
         'Could not open/read/close the startup script {0:s}: {1:s}'.format(
-            script_path, str(exception)))
+            script_path, str(exception))) from exception

--- a/tests/providers/aws/e2e.py
+++ b/tests/providers/aws/e2e.py
@@ -257,7 +257,7 @@ class EndToEndTest(unittest.TestCase):
       except (client.exceptions.ClientError,
               botocore.exceptions.WaiterError) as exception:
         raise RuntimeError('Could not complete cleanup: {0:s}'.format(
-            str(exception)))
+            str(exception))) from exception
       logger.info('Volume {0:s} successfully deleted.'.format(volume.volume_id))
 
 

--- a/tests/providers/azure/e2e.py
+++ b/tests/providers/azure/e2e.py
@@ -223,7 +223,7 @@ class EndToEndTest(unittest.TestCase):
             disk.resource_group_name, disk.name)
       except azure_exceptions.CloudError as exception:
         raise RuntimeError('Could not complete cleanup: {0:s}'.format(
-            str(exception)))
+            str(exception))) from exception
       logger.info('Disk {0:s} successfully deleted.'.format(disk.name))
 
 

--- a/tests/scripts/utils.py
+++ b/tests/scripts/utils.py
@@ -45,12 +45,12 @@ def ReadProjectInfo(keys: List[str]) -> Dict[str, str]:
       project_info = json.load(json_file)  # type: Dict[str, str]
     except ValueError as exception:
       raise RuntimeError(
-          'Cannot parse JSON file. {0:s}'.format(str(exception)))
+          'Cannot parse JSON file. {0:s}'.format(str(exception))) from exception
     json_file.close()
   except OSError as exception:
     raise OSError(
         'Could not open/close file {0:s}: {1:s}'.format(
-            project_info_path, str(exception)))
+            project_info_path, str(exception))) from exception
 
   if not all(key in project_info for key in keys):
     raise ValueError(

--- a/tools/az_cli.py
+++ b/tools/az_cli.py
@@ -188,7 +188,8 @@ def QueryMetrics(args: 'argparse.Namespace') -> None:
       from_date = datetime.strptime(from_date, '%Y-%m-%dT%H:%M:%SZ')
       to_date = datetime.strptime(to_date, '%Y-%m-%dT%H:%M:%SZ')
     except ValueError as exception:
-      raise RuntimeError('Cannot parse date: {0:s}'.format(str(exception)))
+      raise RuntimeError(
+          'Cannot parse date: {0!s}'.format(exception)) from exception
   metrics = az_monitoring.GetMetricsForResource(
       args.resource_id,
       metrics=args.metrics,


### PR DESCRIPTION
The new pylint package (https://github.com/PyCQA/pylint/releases/tag/pylint-2.6.0) adds a few more rules (in particular compliance with https://legacy.python.org/dev/peps/pep-3134/) that fail on our current codebase. 

This PR fixes two rules:
- Compliance with calling `super()` without arguments in Py3 (migrating from `super(Class, self).__init__()` to `super().__init__()`
- Compliance with PEP3134: when catching an exception and raising a different one, use the `raise from` form so that Python outputs a clearer error message (`The above exception was the direct cause of the following exception:` instead of the current `During handling of the above exception, another exception occurred:`)

This should additionally fix current open and failing PRs (#255)

Signed-off-by: Theo Giovanna <gtheo@google.com>