### PR TITLE
Pin minimum version of httplib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -i https://pypi.org/simple
-google-api-core
 google-api-python-client
+google-api-core
 google-auth
 boto3
 botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -i https://pypi.org/simple
-httplib2
+httplib2>=0.15.0
 google-api-python-client
 google-auth
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -i https://pypi.org/simple
 google-api-python-client
-google-api-core
 google-auth
 boto3
 botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -i https://pypi.org/simple
+httplib2
 google-api-python-client
 google-auth
 boto3


### PR DESCRIPTION
Pin httplib2>=0.15.0 until https://github.com/googleapis/google-api-python-client/pull/1050 is merged