### PR TITLE
Add device name to attachDisk calls

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -826,7 +826,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     operation_config = {
         'mode': mode,
         'source': disk.GetSourceString(),
-        'deviceName': disk.GetSourceString(),
+        'deviceName': self.name,
         'boot': False,
         'autoDelete': False,
     }

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -826,7 +826,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     operation_config = {
         'mode': mode,
         'source': disk.GetSourceString(),
-        'deviceName': self.name,
+        'deviceName': disk.name,
         'boot': False,
         'autoDelete': False,
     }

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -826,6 +826,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     operation_config = {
         'mode': mode,
         'source': disk.GetSourceString(),
+        'deviceName': disk.GetSourceString(),
         'boot': False,
         'autoDelete': False,
     }


### PR DESCRIPTION
This is so that we can have a predictable device name in the instance (which is needed by Turbinia).