### PR TITLE
Fix deleteinstance command line function

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -892,7 +892,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
       try:
         disk = GoogleCloudCompute(self.project_id).GetDisk(disk_name=disk_name)
         disk.Delete()
-      except RuntimeError:
+      except (errors.ResourceDeletionError, errors.ResourceNotFoundError):
         logger.info(
             self.FormatLogMessage(
                 'Could not find disk: {0:s}, skipping'.format(disk_name)))

--- a/tools/gcp_cli.py
+++ b/tools/gcp_cli.py
@@ -95,7 +95,7 @@ def DeleteInstance(args: 'argparse.Namespace') -> None:
 
   compute_client = gcp_compute.GoogleCloudCompute(args.project)
   instance = compute_client.GetInstance(instance_name=args.instance_name)
-  instance.Delete(delete_disks=args.delete_disks)
+  instance.Delete(delete_disks=args.delete_all_disks)
 
   print('Instance deleted.')
 


### PR DESCRIPTION
Fix #273 

- Fix attribute selection from argparser
- Fix `try/except` block catching the wrong exception. When `delete_all_disks` is `True`, the library will try to delete the disk that has already been deleted by the `instance delete` operation, thus throwing a `ResourceNotFoundError` error.

```
~/(venv) giovannt0@: cloudforensics gcp <project_id> deleteinstance instance-1 --delete_all_disks
[2020-12-17 14:31:25,239] [libcloudforensics.providers.gcp.internal.compute] INFO     project:<project_id> Deleting Instance: instance-1
[2020-12-17 14:31:43,852] [libcloudforensics.providers.gcp.internal.compute] ERROR    Disk instance-1 was not found in project <project_id>
[2020-12-17 14:31:43,852] [libcloudforensics.providers.gcp.internal.compute] INFO     project:<project_id> Could not find disk: instance-1, skipping
Instance deleted.
```

Despite the logging, the instance and its disk are now deleted as expected. Alternatively we could filter out already deleted disks from the `disks_to_delete` list to prevent `ResourceNotFoundError` from being thrown in the first place.