### PR TITLE
Add ability to remove a service account attachment

### DIFF
--- a/libcloudforensics/errors.py
+++ b/libcloudforensics/errors.py
@@ -69,4 +69,4 @@ class InstanceStateChangeError(LCFError):
   """Error when an issue with changing an instance state is encountered."""
 
 class ServiceAccountRemovalError(LCFError):
-  """Error when an issue with changing an instance state is encountered."""
+  """Error when an issue with removing a service account is encountered."""

--- a/libcloudforensics/errors.py
+++ b/libcloudforensics/errors.py
@@ -64,3 +64,9 @@ class ResourceCreationError(LCFError):
 
 class ResourceDeletionError(LCFError):
   """Error when an issue with deleting a resource is encountered."""
+
+class InstanceStateChangeError(LCFError):
+  """Error when an issue with changing an instance state is encountered."""
+
+class ServiceAccountRemovalError(LCFError):
+  """Error when an issue with changing an instance state is encountered."""

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -399,22 +399,6 @@ def VMRemoveServiceAccount(project_id: str,
   if not initial_state in ('TERMINATED', 'STOPPING'):
     instance.Stop()
 
-  # ... and wait for the stop to complete.
-  wait = 1 # seconds
-  wait_count = 0
-  while current_state != 'TERMINATED':
-    wait *= 2 # exponential backoff
-    wait_count += 1
-
-    if wait_count >= 10:
-      logger.error('Timeout on stopping instance. Exiting.')
-      return False
-
-    logger.info('Waiting {0:d} seconds for instance to stop'.format(wait))
-    time.sleep(wait)
-
-    current_state = instance.GetPowerState()
-
   # Remove the service account
   instance.DetachServiceAccount()
 

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -16,7 +16,6 @@
 
 import base64
 import random
-import time
 from typing import TYPE_CHECKING, List, Tuple, Optional, Dict, Any
 
 from google.auth.exceptions import RefreshError, DefaultCredentialsError
@@ -388,7 +387,6 @@ def VMRemoveServiceAccount(project_id: str,
 
   # Get the initial powered state of the instance
   initial_state = instance.GetPowerState()
-  current_state = initial_state
 
   if not initial_state in valid_starting_states:
     logger.error('Instance "{0:s}" is currently {1:s} which is an invalid '

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -25,7 +25,6 @@ from googleapiclient.errors import HttpError
 from libcloudforensics.providers.gcp.internal import project as gcp_project
 from libcloudforensics.providers.gcp.internal import common
 from libcloudforensics import errors, logging_utils
-from libcloudforensics.errors import ResourceNotFoundError
 
 if TYPE_CHECKING:
   from libcloudforensics.providers.gcp.internal import compute

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -362,7 +362,7 @@ def VMRemoveServiceAccount(project_id: str,
                            instance_name: str,
                            leave_stopped: bool = False) -> bool:
   """
-  Remove a service account attachment from a GCP VM
+  Remove a service account attachment from a GCP VM.
 
   Service account attachments to VMs allow the VM to obtain credentials
   via the instance metadata service to perform API actions. Removing
@@ -375,7 +375,7 @@ def VMRemoveServiceAccount(project_id: str,
     instance_name (str): The name of the virtual machine.
     leave_stopped (bool): Optional. True to leave the machine powered off.
   Returns:
-    success (bool)
+    bool: True if the service account was successfully removed, False otherwise.
   """
   logger.info('Removing service account attachment from "{0:s}",'
               ' in project {1:s}'.format(instance_name, project_id))

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -968,57 +968,61 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
   def Stop(self) -> None:
     """
     Stops the instance.
+
+    Raises:
+      errors.InstanceStateChangeError: If the Stop operation is unsuccessful
     """
 
+    logger.info('Stopping instance "{0:s}"'.format(self.name))
     try:
-      logger.info('Stopping instance "{0:s}"'.format(self.name))
       gce_instance_client = self.GceApi().instances()
       request = gce_instance_client.stop(
           project=self.project_id, instance=self.name, zone=self.zone)
       response = request.execute()
       self.BlockOperation(response, zone=self.zone)
     except HttpError as exception:
-      logger.error((
-          'While stopping GCE instance {0:s} the following error occurred: '
-          '{1:s}').format(self.name, str(exception)))
-      raise errors.InstanceStateChangeError
+      raise errors.InstanceStateChangeError('Could not stop instance: {0:s}'
+          .format(str(exception)), __name__)
 
   def Start(self) -> None:
     """
     Starts the instance.
+
+    Raises:
+      errors.InstanceStateChangeError: If the Start operation is unsuccessful
     """
 
+    logger.info('Starting instance "{0:s}"'.format(self.name))
     try:
-      logger.info('Starting instance "{0:s}"'.format(self.name))
       gce_instance_client = self.GceApi().instances()
       request = gce_instance_client.start(
           project=self.project_id, instance=self.name, zone=self.zone)
       response = request.execute()
       self.BlockOperation(response, zone=self.zone)
     except HttpError as exception:
-      logger.error((
-          'While starting GCE instance {0:s} the following error occurred: '
-          '{1:s}').format(self.name, str(exception)))
-      raise errors.InstanceStateChangeError
+      raise errors.InstanceStateChangeError('Could not start instance: {0:s}'
+          .format(str(exception)), __name__)
 
   def DetachServiceAccount(self) -> None:
     """
     Detach a service account from the instance
+
+    Raises:
+      errors.ServiceAccountRemovalError: if en error occurs while
+          detaching the service account
     """
+
+    logger.info('Detaching service account from instance "{0:s}"'
+        .format(self.name))
     try:
-      logger.info('Detaching service account from instance "{0:s}"'
-          .format(self.name))
       gce_instance_client = self.GceApi().instances()
       request = gce_instance_client.setServiceAccount(
           project=self.project_id, instance=self.name, zone=self.zone, body={})
       response = request.execute()
       self.BlockOperation(response, zone=self.zone)
     except HttpError as exception:
-      logger.error((
-          'While detaching service accountd from instance {0:s} the following '
-          'error occurred: {1:s}').format(self.name, str(exception)))
-      raise errors.ServiceAccountRemovalError
-
+      raise errors.ServiceAccountRemovalError('Service account detatchment '
+          'failure: {0:s}'.format(str(exception)), __name__)
 
 class GoogleComputeDisk(compute_base_resource.GoogleComputeBaseResource):
   """Class representing a Compute Engine disk."""

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -964,7 +964,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     RUNNING, STOPPING, SUSPENDING, SUSPENDED, REPAIRING, and TERMINATED
     """
     return self.GetOperation()['status']
-  
+
   def Stop(self) -> None:
     """
     Stop the instance.
@@ -976,6 +976,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
       request = gce_instance_client.stop(
           project=self.project_id, instance=self.name, zone=self.zone)
       response = request.execute()
+      self.BlockOperation(response, zone=self.zone)
     except HttpError as exception:
       logger.error((
           'While stopping GCE instance {0:s} the following error occurred: '
@@ -993,6 +994,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
       request = gce_instance_client.start(
           project=self.project_id, instance=self.name, zone=self.zone)
       response = request.execute()
+      self.BlockOperation(response, zone=self.zone)
     except HttpError as exception:
       logger.error((
           'While starting GCE instance {0:s} the following error occurred: '
@@ -1010,6 +1012,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
       request = gce_instance_client.setServiceAccount(
           project=self.project_id, instance=self.name, zone=self.zone, body={})
       response = request.execute()
+      self.BlockOperation(response, zone=self.zone)
     except HttpError as exception:
       logger.error((
           'While detaching service accountd from instance {0:s} the following '

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -1017,9 +1017,6 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
       raise errors.ServiceAccountRemovalError
 
 
-
-      
-
 class GoogleComputeDisk(compute_base_resource.GoogleComputeBaseResource):
   """Class representing a Compute Engine disk."""
 

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -963,7 +963,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     this can return one of the following possible values: PROVISIONING, STAGING,
     RUNNING, STOPPING, SUSPENDING, SUSPENDED, REPAIRING, and TERMINATED
     """
-    return self.GetOperation()['status']
+    return str(self.GetOperation()['status'])
 
   def Stop(self) -> None:
     """

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -967,7 +967,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
 
   def Stop(self) -> None:
     """
-    Stop the instance.
+    Stops the instance.
     """
 
     try:
@@ -985,7 +985,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
 
   def Start(self) -> None:
     """
-    Start the instance.
+    Starts the instance.
     """
 
     try:
@@ -1003,7 +1003,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
 
   def DetachServiceAccount(self) -> None:
     """
-    Remove a service account from the instance
+    Detach a service account from the instance
     """
     try:
       logger.info('Detaching service account from instance "{0:s}"'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 -i https://pypi.org/simple
 PyJWT<2  # Bad overlap in azure dependencies
-httplib2
+httplib2>=0.15.0
 google-api-python-client
-google-auth
+google-auth<2.0.0.dev0
+google-api-core<1.26.0.dev0
 boto3
 botocore
 azure-common

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -40,21 +40,22 @@ PROVIDER_TO_FUNC = {
         'querymetrics': az_cli.QueryMetrics
     },
     'gcp': {
+        'bucketacls': gcp_cli.GetBucketACLs,
         'copydisk': gcp_cli.CreateDiskCopy,
         'creatediskgcs': gcp_cli.CreateDiskFromGCSImage,
         'deleteinstance': gcp_cli.DeleteInstance,
+        'deleteobject': gcp_cli.DeleteObject,
+        'listbuckets': gcp_cli.ListBuckets,
         'listdisks': gcp_cli.ListDisks,
         'listinstances': gcp_cli.ListInstances,
         'listlogs': gcp_cli.ListLogs,
+        'listobjects': gcp_cli.ListBucketObjects,
         'listservices': gcp_cli.ListServices,
+        'objectmetadata': gcp_cli.GetGCSObjectMetadata,
+        'quarantinevm': gcp_cli.InstanceNetworkQuarantine,
         'querylogs': gcp_cli.QueryLogs,
         'startvm': gcp_cli.StartAnalysisVm,
-        'bucketacls': gcp_cli.GetBucketACLs,
-        'objectmetadata': gcp_cli.GetGCSObjectMetadata,
-        'listbuckets': gcp_cli.ListBuckets,
-        'listobjects': gcp_cli.ListBucketObjects,
-        'deleteobject': gcp_cli.DeleteObject,
-        'quarantinevm': gcp_cli.InstanceNetworkQuarantine
+        'vmremoveserviceaccount': gcp_cli.VMRemoveServiceAccount
     }
 }
 
@@ -365,6 +366,13 @@ def Main() -> None:
                 ('--exempted_src_ips', 'Comma separated list of source IPs '
                     'to exempt from ingress firewall rules.', None),
                 ('--enable_logging', 'Enable firewall logging.', False),
+            ])
+  AddParser('gcp', gcp_subparsers, 'vmremoveserviceaccount',
+            'Removes a service account attachment from a VM.',
+            args=[
+                ('instance_name', 'Name of the instance to affect', ''),
+                ('--leave_stopped', 'Leave the machine TERMINATED after removing '
+                    'the service account (default: False)', False)
             ])
 
   if len(sys.argv) == 1:

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -371,8 +371,8 @@ def Main() -> None:
             'Removes a service account attachment from a VM.',
             args=[
                 ('instance_name', 'Name of the instance to affect', ''),
-                ('--leave_stopped', 'Leave the machine TERMINATED after removing '
-                    'the service account (default: False)', False)
+                ('--leave_stopped', 'Leave the machine TERMINATED after '
+                    'removing the service account (default: False)', False)
             ])
 
   if len(sys.argv) == 1:

--- a/tools/gcp_cli.py
+++ b/tools/gcp_cli.py
@@ -304,3 +304,12 @@ def InstanceNetworkQuarantine(args: 'argparse.Namespace') -> None:
       return
   forensics.InstanceNetworkQuarantine(args.project,
       args.instance_name, exempted_ips, args.enable_logging )
+
+def VMRemoveServiceAccount(args: 'argparse.Namespace') -> None:
+  """Removes an attached service account from a VM instance.
+  Requires the instance to be stopped, if it isn't already.
+  Args:
+    args (argparse.Namespace): Arguments from ArgumentParser.
+  """
+  forensics.VMRemoveServiceAccount(args.project, args.instance_name,
+      args.leave_stopped)


### PR DESCRIPTION
From [1]:

Feature - Upon discovery of a compromise, a operator should be able to quickly remove service accounts attached to instances to prevent any API activity from a malicious actor with access.

Note that an instance must be stopped to be able to remove the account, so, the instance is stopped first. An option to leave the instance in the stopped state, or to restart it is provided. 

[1] https://github.com/google/cloud-forensics-utils/issues/278