### PR TITLE
Add sleep() in Azure e2e to allow for deleteOperation propagation

### DIFF
--- a/.github/workflows/install_test_setup_py.yml
+++ b/.github/workflows/install_test_setup_py.yml
@@ -19,8 +19,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Update PIP
-      run: python -m pip install -U pip
+    - name: Update PIP and install crypto package
+      run: python -m pip install -U pip && pip install cryptography
     - name: Install wheel
       run: pip install wheel
     - name: Install dependencies through setup.py

--- a/.github/workflows/install_test_setup_py.yml
+++ b/.github/workflows/install_test_setup_py.yml
@@ -19,6 +19,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Update PIP
+      run: python -m pip install -U pip
     - name: Install wheel
       run: pip install wheel
     - name: Install dependencies through setup.py

--- a/tests/providers/azure/e2e.py
+++ b/tests/providers/azure/e2e.py
@@ -143,11 +143,11 @@ class EndToEndTest(unittest.TestCase):
     # permit same-name disks in different regions.
     operation = self.az.compute.compute_client.disks.begin_delete(
         disk_copy.resource_group_name, disk_copy.name)
-    operation.wait()
     # Delete operation takes some time to propagate within Azure, which in
-    # some cases causes the next test to fail. Therefore we wait a minute
-    # before moving on to the next test.
-    sleep(60)
+    # some cases causes the next test to fail. Therefore we have to wait for
+    # completion.
+    while not operation.done():
+      sleep(5)
 
   @typing.no_type_check
   def testStartVm(self):

--- a/tests/providers/azure/e2e.py
+++ b/tests/providers/azure/e2e.py
@@ -144,6 +144,10 @@ class EndToEndTest(unittest.TestCase):
     operation = self.az.compute.compute_client.disks.begin_delete(
         disk_copy.resource_group_name, disk_copy.name)
     operation.wait()
+    # Delete operation takes some time to propagate within Azure, which in
+    # some cases causes the next test to fail. Therefore we wait a minute
+    # before moving on to the next test.
+    sleep(60)
 
   @typing.no_type_check
   def testStartVm(self):

--- a/tests/providers/azure/internal/test_compute.py
+++ b/tests/providers/azure/internal/test_compute.py
@@ -225,7 +225,7 @@ class AZComputeTest(unittest.TestCase):
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.GetInstance')
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute._GetInstanceType')
   @mock.patch('libcloudforensics.providers.azure.internal.network.AZNetwork.CreateNetworkInterface')
-  @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.begin_create_or_update')
+  @mock.patch('azure.mgmt.compute.v2020_12_01.operations._virtual_machines_operations.VirtualMachinesOperations.begin_create_or_update')
   @typing.no_type_check
   def testGetOrCreateAnalysisVm(self,
                                 mock_vm,
@@ -262,7 +262,7 @@ class AZComputeTest(unittest.TestCase):
     self.assertEqual('fake-analysis-vm-name', vm.name)
     self.assertTrue(created)
 
-  @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machine_sizes_operations.VirtualMachineSizesOperations.list')
+  @mock.patch('azure.mgmt.compute.v2020_12_01.operations._virtual_machine_sizes_operations.VirtualMachineSizesOperations.list')
   @typing.no_type_check
   def testListVMSizes(self, mock_list):
     """Test that instance types are correctly listed."""
@@ -292,7 +292,7 @@ class AZVirtualMachineTest(unittest.TestCase):
   # pylint: disable=line-too-long
 
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
-  @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')
+  @mock.patch('azure.mgmt.compute.v2020_12_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')
   @typing.no_type_check
   def testGetBootDisk(self, mock_get_vm, mock_list_disk):
     """Test that the boot disk from an instance is retrieved."""
@@ -321,7 +321,7 @@ class AZVirtualMachineTest(unittest.TestCase):
         'Microsoft.Compute/type/fake-vm-name', str(error.exception))
 
   @mock.patch('libcloudforensics.providers.azure.internal.compute.AZCompute.ListDisks')
-  @mock.patch('azure.mgmt.compute.v2020_06_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')
+  @mock.patch('azure.mgmt.compute.v2020_12_01.operations._virtual_machines_operations.VirtualMachinesOperations.get')
   @typing.no_type_check
   def testListDisks(self, mock_get_vm, mock_list_disk):
     """Test that disks from an instance are correctly listed."""

--- a/tests/providers/azure/internal/test_storage.py
+++ b/tests/providers/azure/internal/test_storage.py
@@ -26,8 +26,8 @@ class AZStorageTest(unittest.TestCase):
   """Test Azure storage class."""
   # pylint: disable=line-too-long
 
-  @mock.patch('azure.mgmt.storage.v2019_06_01.operations._storage_accounts_operations.StorageAccountsOperations.list_keys')
-  @mock.patch('azure.mgmt.storage.v2019_06_01.operations._storage_accounts_operations.StorageAccountsOperations.begin_create')
+  @mock.patch('azure.mgmt.storage.v2021_01_01.operations._storage_accounts_operations.StorageAccountsOperations.list_keys')
+  @mock.patch('azure.mgmt.storage.v2021_01_01.operations._storage_accounts_operations.StorageAccountsOperations.begin_create')
   @typing.no_type_check
   def testCreateStorageAccount(self, mock_create, mock_list_keys):
     """Test that a storage account is created and its information retrieved"""


### PR DESCRIPTION
- Fix e2e test, where sometimes a resource's deletion is propagated too slow and tests depending on similar resources fail.
- Fix Azure unit tests versioning
- Fix GitHub action for py3.6 where the crypto package needs to be installed first as otherwise it fails in the global setup.

Signed-off-by: Theo Giovanna <gtheo@google.com>