### PR TITLE
Add support for env var credentials

### DIFF
--- a/libcloudforensics/logging_utils.py
+++ b/libcloudforensics/logging_utils.py
@@ -109,7 +109,7 @@ def SetUpLogger(name: str) -> None:
     name (str): The name for the logger.
   """
   # We can ignore the mypy warning below since the manager is created at runtime
-  add_handler = name not in logging.root.manager.loggerDict  # type: ignore
+  add_handler = name not in logging.root.manager.loggerDict  # type: ignore pylint: disable=no-member
   logger = logging.getLogger(name)
   logger.setLevel(logging.INFO)
   if add_handler:

--- a/libcloudforensics/logging_utils.py
+++ b/libcloudforensics/logging_utils.py
@@ -109,7 +109,9 @@ def SetUpLogger(name: str) -> None:
     name (str): The name for the logger.
   """
   # We can ignore the mypy warning below since the manager is created at runtime
-  add_handler = name not in logging.root.manager.loggerDict  # type: ignore pylint: disable=no-member
+  #pylint: disable=no-member
+  add_handler = name not in logging.root.manager.loggerDict  # type: ignore
+  # pylint: enable=no-member
   logger = logging.getLogger(name)
   logger.setLevel(logging.INFO)
   if add_handler:

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -80,7 +80,7 @@ class AWSAccount:
           aws_access_key_id=aws_access_key_id,
           aws_secret_access_key=aws_secret_access_key,
           aws_session_token=aws_session_token)
-    elif (aws_profile):
+    elif aws_profile:
       self.aws_profile = aws_profile
       self.session = boto3.session.Session(profile_name=self.aws_profile)
     else:

--- a/libcloudforensics/providers/aws/internal/account.py
+++ b/libcloudforensics/providers/aws/internal/account.py
@@ -70,7 +70,6 @@ class AWSAccount:
           using these parameters instead of the credential file.
     """
 
-    self.aws_profile = aws_profile or 'default'
     self.default_availability_zone = default_availability_zone
     # The region is given by the zone minus the last letter
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#using-regions-availability-zones-describe # pylint: disable=line-too-long
@@ -81,8 +80,11 @@ class AWSAccount:
           aws_access_key_id=aws_access_key_id,
           aws_secret_access_key=aws_secret_access_key,
           aws_session_token=aws_session_token)
-    else:
+    elif (aws_profile):
+      self.aws_profile = aws_profile
       self.session = boto3.session.Session(profile_name=self.aws_profile)
+    else:
+      self.session = boto3.session.Session()
 
     self._ec2 = None  # type: Optional[ec2.EC2]
     self._ebs = None  # type: Optional[ebs.EBS]


### PR DESCRIPTION
As per issue https://github.com/google/cloud-forensics-utils/issues/308, add in support for environment variables as credential storage for AWS. 