### PR TITLE
Do not cache the result of CreateService

### DIFF
--- a/libcloudforensics/providers/gcp/internal/build.py
+++ b/libcloudforensics/providers/gcp/internal/build.py
@@ -28,9 +28,6 @@ class GoogleCloudBuild:
 
   Dictionary objects content can be found in
   https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds
-
-  Attributes:
-    gcb_api_client: Client to interact with GCB APIs.
   """
   CLOUD_BUILD_API_VERSION = 'v1'
 
@@ -41,7 +38,6 @@ class GoogleCloudBuild:
       project_id (str): Google Cloud project ID.
     """
 
-    self.gcb_api_client = None
     self.project_id = project_id
 
   def GcbApi(self) -> 'googleapiclient.discovery.Resource':
@@ -51,9 +47,8 @@ class GoogleCloudBuild:
       googleapiclient.discovery.Resource: A Google Cloud Build service object.
     """
 
-    self.gcb_api_client = common.CreateService(
+    return common.CreateService(
         'cloudbuild', self.CLOUD_BUILD_API_VERSION)
-    return self.gcb_api_client
 
   def CreateBuild(self, build_body: Dict[str, Any]) -> Dict[str, Any]:
     """Create a cloud build.

--- a/libcloudforensics/providers/gcp/internal/build.py
+++ b/libcloudforensics/providers/gcp/internal/build.py
@@ -51,8 +51,6 @@ class GoogleCloudBuild:
       googleapiclient.discovery.Resource: A Google Cloud Build service object.
     """
 
-    if self.gcb_api_client:
-      return self.gcb_api_client
     self.gcb_api_client = common.CreateService(
         'cloudbuild', self.CLOUD_BUILD_API_VERSION)
     return self.gcb_api_client

--- a/libcloudforensics/providers/gcp/internal/cloudsql.py
+++ b/libcloudforensics/providers/gcp/internal/cloudsql.py
@@ -47,8 +47,6 @@ class GoogleCloudSQL:
       googleapiclient.discovery.Resource: A Google CloudSQL service object.
     """
 
-    if self.gcsql_api_client:
-      return self.gcsql_api_client
     self.gcsql_api_client = common.CreateService(
         'sqladmin', self.SQLADMIN_API_VERSION)
     return self.gcsql_api_client

--- a/libcloudforensics/providers/gcp/internal/cloudsql.py
+++ b/libcloudforensics/providers/gcp/internal/cloudsql.py
@@ -25,7 +25,6 @@ class GoogleCloudSQL:
   """Class to call Google CloudSQL APIs.
 
   Attributes:
-    gcsql_api_client: Client to interact with GCSql APIs.
     project_id: Google Cloud project ID.
   """
   SQLADMIN_API_VERSION = 'v1beta4'
@@ -37,7 +36,6 @@ class GoogleCloudSQL:
       project_id (str): Optional. Google Cloud project ID.
     """
 
-    self.gcsql_api_client = None
     self.project_id = project_id
 
   def GoogleCloudSQLApi(self) -> 'googleapiclient.discovery.Resource':
@@ -47,9 +45,8 @@ class GoogleCloudSQL:
       googleapiclient.discovery.Resource: A Google CloudSQL service object.
     """
 
-    self.gcsql_api_client = common.CreateService(
+    return common.CreateService(
         'sqladmin', self.SQLADMIN_API_VERSION)
-    return self.gcsql_api_client
 
   def ListCloudSQLInstances(self) -> List[Dict[str, Any]]:
     """List instances of Google CloudSQL within a project.

--- a/libcloudforensics/providers/gcp/internal/function.py
+++ b/libcloudforensics/providers/gcp/internal/function.py
@@ -33,7 +33,6 @@ class GoogleCloudFunction:
 
   Attributes:
     project_id: Google Cloud project ID.
-    gcf_api_client: Client to interact with GCF APIs.
   """
 
   CLOUD_FUNCTIONS_API_VERSION = 'v1'
@@ -45,7 +44,6 @@ class GoogleCloudFunction:
       project_id (str): The name of the project.
     """
 
-    self.gcf_api_client = None
     self.project_id = project_id
 
   def GcfApi(self) -> 'googleapiclient.discovery.Resource':
@@ -56,9 +54,8 @@ class GoogleCloudFunction:
           object.
     """
 
-    self.gcf_api_client = common.CreateService(
+    return common.CreateService(
         'cloudfunctions', self.CLOUD_FUNCTIONS_API_VERSION)
-    return self.gcf_api_client
 
   def ExecuteFunction(self,
                       function_name: str,

--- a/libcloudforensics/providers/gcp/internal/function.py
+++ b/libcloudforensics/providers/gcp/internal/function.py
@@ -56,8 +56,6 @@ class GoogleCloudFunction:
           object.
     """
 
-    if self.gcf_api_client:
-      return self.gcf_api_client
     self.gcf_api_client = common.CreateService(
         'cloudfunctions', self.CLOUD_FUNCTIONS_API_VERSION)
     return self.gcf_api_client

--- a/libcloudforensics/providers/gcp/internal/gke.py
+++ b/libcloudforensics/providers/gcp/internal/gke.py
@@ -25,18 +25,8 @@ class GoogleKubernetesEngine:
   """Class to call Google Kubernetes Engine (GKE) APIs.
 
   https://cloud.google.com/kubernetes-engine/docs/reference/rest
-
-  Attributes:
-    gke_api_client (googleapiclient.discovery.Resource): Client to interact
-        with GKE APIs.
   """
   GKE_API_VERSION = 'v1'
-
-  def __init__(self) -> None:
-    """Initialize the GoogleCloudStorage object.
-    """
-
-    self.gke_api_client = None
 
   def GkeApi(self) -> 'googleapiclient.discovery.Resource':
     """Gets a Google Container service object.
@@ -47,9 +37,8 @@ class GoogleKubernetesEngine:
       googleapiclient.discovery.Resource: A Google Container service object.
     """
 
-    self.gke_api_client = common.CreateService(
+    return common.CreateService(
         'container', self.GKE_API_VERSION)
-    return self.gke_api_client
 
   def GetCluster(self, name: str) -> Dict[str, Any]:
     """ Gets the details of a specific cluster.

--- a/libcloudforensics/providers/gcp/internal/gke.py
+++ b/libcloudforensics/providers/gcp/internal/gke.py
@@ -47,8 +47,6 @@ class GoogleKubernetesEngine:
       googleapiclient.discovery.Resource: A Google Container service object.
     """
 
-    if self.gke_api_client:
-      return self.gke_api_client
     self.gke_api_client = common.CreateService(
         'container', self.GKE_API_VERSION)
     return self.gke_api_client

--- a/libcloudforensics/providers/gcp/internal/log.py
+++ b/libcloudforensics/providers/gcp/internal/log.py
@@ -27,7 +27,6 @@ class GoogleCloudLog:
 
   Attributes:
     project_ids: List of Google Cloud project IDs.
-    gcl_api_client: Client to interact with GCP logging API.
 
   Example use:
     # pylint: disable=line-too-long
@@ -46,7 +45,6 @@ class GoogleCloudLog:
       project_ids (List[str]): List of project IDs.
     """
     self.project_ids = project_ids
-    self.gcl_api_client = None
 
   def GclApi(self) -> 'googleapiclient.discovery.Resource':
     """Get a Google Compute Logging service object.
@@ -56,9 +54,8 @@ class GoogleCloudLog:
           object.
     """
 
-    self.gcl_api_client = common.CreateService(
+    return common.CreateService(
         'logging', self.LOGGING_API_VERSION)
-    return self.gcl_api_client
 
   def ListLogs(self) -> List[str]:
     """List logs in project.

--- a/libcloudforensics/providers/gcp/internal/log.py
+++ b/libcloudforensics/providers/gcp/internal/log.py
@@ -56,8 +56,6 @@ class GoogleCloudLog:
           object.
     """
 
-    if self.gcl_api_client:
-      return self.gcl_api_client
     self.gcl_api_client = common.CreateService(
         'logging', self.LOGGING_API_VERSION)
     return self.gcl_api_client

--- a/libcloudforensics/providers/gcp/internal/monitoring.py
+++ b/libcloudforensics/providers/gcp/internal/monitoring.py
@@ -30,7 +30,6 @@ class GoogleCloudMonitoring:
 
   Attributes:
     project_id: Project name.
-    gcm_api_client: Client to interact with Monitoring APIs.
   """
   CLOUD_MONITORING_API_VERSION = 'v3'
 
@@ -41,7 +40,6 @@ class GoogleCloudMonitoring:
       project_id (str): The name of the project.
     """
 
-    self.gcm_api_client = None
     self.project_id = project_id
 
   def GcmApi(self) -> 'googleapiclient.discovery.Resource':
@@ -51,9 +49,8 @@ class GoogleCloudMonitoring:
       googleapiclient.discovery.Resource: A Google Cloud Monitoring
           service object.
     """
-    self.gcm_api_client = common.CreateService(
+    return common.CreateService(
         'monitoring', self.CLOUD_MONITORING_API_VERSION)
-    return self.gcm_api_client
 
   def ActiveServices(self, timeframe: int = 30) -> Dict[str, int]:
     """List active services in the project (default: last 30 days).

--- a/libcloudforensics/providers/gcp/internal/monitoring.py
+++ b/libcloudforensics/providers/gcp/internal/monitoring.py
@@ -51,8 +51,6 @@ class GoogleCloudMonitoring:
       googleapiclient.discovery.Resource: A Google Cloud Monitoring
           service object.
     """
-    if self.gcm_api_client:
-      return self.gcm_api_client
     self.gcm_api_client = common.CreateService(
         'monitoring', self.CLOUD_MONITORING_API_VERSION)
     return self.gcm_api_client

--- a/libcloudforensics/providers/gcp/internal/storage.py
+++ b/libcloudforensics/providers/gcp/internal/storage.py
@@ -80,8 +80,6 @@ class GoogleCloudStorage:
       googleapiclient.discovery.Resource: A Google Cloud Storage service object.
     """
 
-    if self.gcs_api_client:
-      return self.gcs_api_client
     self.gcs_api_client = common.CreateService(
         'storage', self.CLOUD_STORAGE_API_VERSION)
     return self.gcs_api_client

--- a/libcloudforensics/providers/gcp/internal/storage.py
+++ b/libcloudforensics/providers/gcp/internal/storage.py
@@ -58,7 +58,6 @@ class GoogleCloudStorage:
   """Class to call Google Cloud Storage APIs.
 
   Attributes:
-    gcs_api_client: Client to interact with GCS APIs.
     project_id: Google Cloud project ID.
   """
   CLOUD_STORAGE_API_VERSION = 'v1'
@@ -70,7 +69,6 @@ class GoogleCloudStorage:
       project_id (str): Optional. Google Cloud project ID.
     """
 
-    self.gcs_api_client = None
     self.project_id = project_id
 
   def GcsApi(self) -> 'googleapiclient.discovery.Resource':
@@ -80,9 +78,8 @@ class GoogleCloudStorage:
       googleapiclient.discovery.Resource: A Google Cloud Storage service object.
     """
 
-    self.gcs_api_client = common.CreateService(
+    return common.CreateService(
         'storage', self.CLOUD_STORAGE_API_VERSION)
-    return self.gcs_api_client
 
   def GetObjectMetadata(self,
                         gcs_path: str,


### PR DESCRIPTION
Calls to `GoogleCloudFunction` would otherwise retain stale credentials if the object was reused to call `ExecuteFunction` over long periods of time 