### PR TITLE
Instance profile mitigations for AWS - Issue 341

### DIFF
--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -503,8 +503,9 @@ def InstanceProfileMitigator(
     instance_id: str,
     revoke_existing: bool = False
     ) -> None:
-  """Remove an instance profile attachment from an instance. Also, optionally
-  revoke existing issued tokens for the profile.
+  """Remove an instance profile attachment from an instance.
+
+  Also, optionally revoke existing issued tokens for the profile.
 
   Args:
     zone (str): AWS Availability Zone the instance is in.
@@ -523,7 +524,7 @@ def InstanceProfileMitigator(
   if not profile or not assoc_id:
     raise errors.ResourceNotFoundError(
         'Instance not found or does not have a profile attachment: {0:s}'.
-        format(instance_id), __name__)
+          format(instance_id), __name__)
 
   logger.info('Removing profile attachment')
   aws_account.ec2.DisassociateInstanceProfile(assoc_id)

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -510,7 +510,7 @@ def InstanceProfileMitigator(
         'Instance not found or does not have a profile attachment: {0:s}'.
         format(instance_id), __name__)
 
-#  aws_account.ec2.DisassociateInstanceProfile(assoc_id)
+  aws_account.ec2.DisassociateInstanceProfile(assoc_id)
 
   if revoke_existing:
     role_name = profile.split('/')[1]

--- a/libcloudforensics/providers/aws/internal/ec2.py
+++ b/libcloudforensics/providers/aws/internal/ec2.py
@@ -689,17 +689,23 @@ class EC2:
         attachment, and the Arn of the Instance profile attached. Both are None
         if no profile is attached, or the instance cannot be found.
     """
-    client = self.aws_account.ClientApi(common.EC2_SERVICE)
-    response = client.describe_iam_instance_profile_associations(
-      Filters=[{
-            'Name': 'instance-id',
-            'Values': [instance_id]
-      }])
-    if not response['IamInstanceProfileAssociations']:
-      return '', ''
-    return response['IamInstanceProfileAssociations'][0]['AssociationId'],\
-      response['IamInstanceProfileAssociations'][0]['IamInstanceProfile']\
-        ['Arn']
+    try:
+      client = self.aws_account.ClientApi(common.EC2_SERVICE)
+      response = client.describe_iam_instance_profile_associations(
+        Filters=[{
+              'Name': 'instance-id',
+              'Values': [instance_id]
+        }])
+      print(response)
+      if not response['IamInstanceProfileAssociations']:
+        return '', ''
+      return response['IamInstanceProfileAssociations'][0]['AssociationId'],\
+        response['IamInstanceProfileAssociations'][0]['IamInstanceProfile']\
+          ['Arn']
+    except  client.exceptions.ClientError as exception:
+      raise errors.ResourceNotFoundError(
+        'Instance does not exist: {0!s}'.format(
+           exception), __name__) from exception
 
   def DisassociateInstanceProfile(
       self,

--- a/libcloudforensics/providers/aws/internal/ec2.py
+++ b/libcloudforensics/providers/aws/internal/ec2.py
@@ -672,3 +672,48 @@ class EC2:
       raise errors.ResourceCreationError(
         'Could not modify instance attributes: {0!s}'.format(
            exception), __name__) from exception
+
+  def GetInstanceProfileAttachment(
+      self,
+      instance_id: str) -> Tuple[str, str]:
+    """Get the instance profile attached to the instance, if any.
+
+    Args:
+      instance_id (str): The instance ID (i-xxxxxx)
+
+    Returns:
+      Tuple[str, str]: A tuple containing the association id of the profile
+        attachment, and the Arn of the Instance profile attached. Both are None
+        if no profile is attached, or the instance cannot be found.
+    """
+    client = self.aws_account.ClientApi(common.EC2_SERVICE)
+    response = client.describe_iam_instance_profile_associations(
+      Filters=[{
+            'Name': 'instance-id',
+            'Values': [instance_id]
+      }])
+    if not response['IamInstanceProfileAssociations']:
+      return '', ''
+    return response['IamInstanceProfileAssociations'][0]['AssociationId'],\
+      response['IamInstanceProfileAssociations'][0]['IamInstanceProfile']\
+        ['Arn']
+
+  def DisassociateInstanceProfile(
+      self,
+      assoc_id: str) -> None:
+    """Remove an instance profile attachment from an instance.
+
+    Args:
+      assoc_id (str): The instance profile association ID. Can be retrieved via
+        ec2.GetInstanceProfileAttachment.
+
+    Raises:
+      ResourceNotFoundError: If the assoc_id cannot be found.
+    """
+    try:
+      client = self.aws_account.ClientApi(common.EC2_SERVICE)
+      client.disassociate_iam_instance_profile(AssociationId=assoc_id)
+    except client.exceptions.ClientError as exception:
+      raise errors.ResourceNotFoundError(
+        'AssociationID {0:s} not found: {1!s}'.format(assoc_id,
+           exception), __name__) from exception

--- a/libcloudforensics/providers/aws/internal/iam.py
+++ b/libcloudforensics/providers/aws/internal/iam.py
@@ -297,8 +297,10 @@ class IAM:
       # It doesn't matter if this fails.
 
   def RevokeOldSessionsForRole(self, role_name: str) -> None:
-    """Revoke old session tokens for a role. This is acheived by adding an
-    inline policy to the role, Deny *:* on the condition of TokenIssueTime.
+    """Revoke old session tokens for a role.
+
+    This is acheived by adding an inline policy to the role, Deny *:* on the
+    condition of TokenIssueTime.
 
     Args:
       role_name (str): The role name to act on.

--- a/libcloudforensics/providers/aws/internal/iampolicies/revoke_old_sessions.json
+++ b/libcloudforensics/providers/aws/internal/iampolicies/revoke_old_sessions.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
+        "DateLessThan": {
+          "aws:TokenIssueTime": "DATE"
+        }
+      }
+    }
+  ]
+}

--- a/tools/aws_cli.py
+++ b/tools/aws_cli.py
@@ -287,3 +287,13 @@ def InstanceNetworkQuarantine(args: 'argparse.Namespace') -> None:
       return
   forensics.InstanceNetworkQuarantine(args.zone,
       args.instance_id, exempted_src_subnets)
+
+def InstanceProfileMitigator(args: 'argparse.Namespace') -> None:
+  """Remove an instance profile attachment from an instance. Also, optionally
+  revoke existing issued tokens for the profile.
+
+  Args:
+    args (argparse.Namespace): Arguments from ArgumentParser.
+  """
+
+  forensics.InstanceProfileMitigator(args.zone, args.instance_id, args.revoke)

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -31,6 +31,7 @@ PROVIDER_TO_FUNC = {
         'deleteinstance': aws_cli.DeleteInstance,
         'gcstos3': aws_cli.GCSToS3,
         'imageebssnapshottos3': aws_cli.ImageEBSSnapshotToS3,
+        'instanceprofilemitigator': aws_cli.InstanceProfileMitigator,
         'listdisks': aws_cli.ListVolumes,
         'listimages': aws_cli.ListImages,
         'listinstances': aws_cli.ListInstances,
@@ -254,6 +255,15 @@ def Main() -> None:
                     None),
                 ('--exempted_src_subnets', 'Comma separated list of source '
                     'subnets to exempt from ingress firewall rules.', None)
+            ])
+  AddParser('aws', aws_subparsers, 'instanceprofilemitigator',
+            'Remove an instance profile from an instance, and optionally '
+            'revoke all previously issued temporary credentials.',
+            args=[
+                ('instance_id', 'ID (i-xxxxxx) of the instance to quarantine.',
+                    None),
+                ('--revoke', 'Revoke existing temporary creds for the instance'
+                ' profile.', False)
             ])
 
   # Azure parser options


### PR DESCRIPTION
Implement instance profile mitigations for AWS EC2 instances. This takes two actions:

- Remove the instance profile from an instance, and
- Optionally, add an inline policy to the attached role that denies access to old issued tokens (can be thought of as revoking already issued tokens.)

closes #341 