### PR TITLE
Remove external IPs when putting an instance into network quarantine (GCP)

### DIFF
--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -362,6 +362,7 @@ def InstanceNetworkQuarantine(project_id: str,
   # Then remove the VM's external IP address, to break all ongoing
   # connections
   instance.RemoveExternalIps()
+  logger.info(project.compute.ListReservedExternalIps(instance.zone))
 
 def VMRemoveServiceAccount(project_id: str,
                            instance_name: str,

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -361,8 +361,21 @@ def InstanceNetworkQuarantine(project_id: str,
               instance.zone, instance_name, project_id))
   # Then remove the VM's external IP address, to break all ongoing
   # connections
-  instance.RemoveExternalIps()
-  logger.info(project.compute.ListReservedExternalIps(instance.zone))
+  logger.info("Removing external IP addresses to break ongoing connections")
+  removed_ips = instance.RemoveExternalIps()
+  # Now re-assign the IP address
+  available_ips = set(project.compute.ListReservedExternalIps(instance.zone))
+  for net_if, removed_ip in removed_ips.items():
+    if removed_ip in available_ips:
+      # IP address was static, re-assign static
+      logger.info("Re-assigning static IP {} to {}".format(
+        removed_ip,
+        net_if))
+      instance.AssignExternalIp(net_if, removed_ip)
+    else:
+      # IP address was ephemeral, re-assign ephemeral
+      logger.info("Re-assigning ephemeral IP to {}".format(net_if))
+      instance.AssignExternalIp(net_if, None)
 
 def VMRemoveServiceAccount(project_id: str,
                            instance_name: str,

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -361,20 +361,20 @@ def InstanceNetworkQuarantine(project_id: str,
               instance.zone, instance_name, project_id))
   # Then remove the VM's external IP address, to break all ongoing
   # connections
-  logger.info("Removing external IP addresses to break ongoing connections")
+  logger.info('Removing external IP addresses to break ongoing connections')
   removed_ips = instance.RemoveExternalIps()
   # Now re-assign the IP address
   available_ips = set(project.compute.ListReservedExternalIps(instance.zone))
   for net_if, removed_ip in removed_ips.items():
     if removed_ip in available_ips:
       # IP address was static, re-assign static
-      logger.info("Re-assigning static IP {} to {}".format(
+      logger.info('Re-assigning static IP {0:s} to {1:s}'.format(
         removed_ip,
         net_if))
       instance.AssignExternalIp(net_if, removed_ip)
     else:
       # IP address was ephemeral, re-assign ephemeral
-      logger.info("Re-assigning ephemeral IP to {}".format(net_if))
+      logger.info('Re-assigning ephemeral IP to {0:s}'.format(net_if))
       instance.AssignExternalIp(net_if, None)
 
 def VMRemoveServiceAccount(project_id: str,

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -359,6 +359,9 @@ def InstanceNetworkQuarantine(project_id: str,
         'gcloud compute ssh --zone "{0:s}" "{1:s}" --project "{2:s}"\n'
         'Connecting from the browser via GCP console will not work.'.format(
               instance.zone, instance_name, project_id))
+  # Then remove the VM's external IP address, to break all ongoing
+  # connections
+  instance.RemoveExternalIps()
 
 def VMRemoveServiceAccount(project_id: str,
                            instance_name: str,

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -1008,7 +1008,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     Args:
       net_if (str): The instance's network interface to which the IP address
         must be assigned.
-      ip_addr (Optional[str]): The static IP address that exposes the network
+      ip_addr (str): Optional. The static IP address that exposes the network
         interface. If None, the assigned IP address will be ephemeral.
     """
     body = {}
@@ -1026,9 +1026,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     self.BlockOperation(response, self.zone)
 
   def RemoveExternalIps(self) -> Dict[str, str]:
-    """
-    Removes any external IP of the instance, thus breaking
-    any ongoing connections.
+    """Removes any external IP of the instance, breaking ongoing connections.
 
     Note that if the instance's IP address was static, that
     the IP will still belong to the project.

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -417,9 +417,13 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     return self._ListByLabel(
         labels_filter, disk_service_object, filter_union)
 
-  def ListReservedExternalIps(self, region: str) -> List[str]:
-    request = self.GceApi().addresses().list(project=self.project_id, region=region)
-    response = self.BlockOperation(request.execute())
+  def ListReservedExternalIps(self, zone: str) -> List[str]:
+    # Convert zone to region
+    region = '-'.join(zone.split('-')[:-1])
+    # Request list of addresses
+    addresses_client = self.GceApi().addresses()
+    request = addresses_client.list(project=self.project_id, region=region)
+    response = request.execute()
     addresses = []
     for address in response.get('items', []):
       is_reserved = address['status'] == 'RESERVED'

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -418,8 +418,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
         labels_filter, disk_service_object, filter_union)
 
   def ListReservedExternalIps(self, zone: str) -> List[str]:
-    """Lists all static external IP addresses that are reserved (i.e. not in
-    use) and can be used in a particular zone.
+    """Lists all static external IP addresses that are available to a zone.
 
     The method first converts the zone to a region,
     and then queries the GCE addresses resource.
@@ -433,7 +432,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     # Convert zone to region
     zone_parts = zone.split('-')
     if len(zone_parts) != 3:
-      raise ValueError("Invalid zone: {}.")
+      raise ValueError('Invalid zone: {0:s}.'.format(zone))
     region = '-'.join(zone_parts[:-1])
     # Request list of addresses
     addresses_client = self.GceApi().addresses()
@@ -1049,7 +1048,7 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
       external_ip_address = access_config['natIP']
       # Inform analyst of the deletion
       logger.info(
-        "Deleting access config for {} (external IP: {})".format(
+        'Deleting access config for {0:s} (external IP: {1:s})'.format(
           self.name,
           external_ip_address,
         ))

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -417,6 +417,17 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     return self._ListByLabel(
         labels_filter, disk_service_object, filter_union)
 
+  def ListReservedExternalIps(self, region: str) -> List[str]:
+    request = self.GceApi().addresses().list(project=self.project_id, region=region)
+    response = self.BlockOperation(request.execute())
+    addresses = []
+    for address in response.get('items', []):
+      is_reserved = address['status'] == 'RESERVED'
+      is_external = address['addressType'] == 'EXTERNAL'
+      if is_reserved and is_external:
+        addresses.append(address['address'])
+    return addresses
+
   def _ListByLabel(self,
                    labels_filter: Dict[str, str],
                    service_object: 'googleapiclient.discovery.Resource',

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -441,7 +441,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     # Request list of addresses
     addresses_client = self.GceApi().addresses()
     params = {
-      'project': self.project_id, 
+      'project': self.project_id,
       'region': region
    }
     try:


### PR DESCRIPTION
Closes #347 

The current way GCE instances are put into quarantine is via firewall rules. This prevents new connections, but does not break ongoing connections. Removing the external IP addresses will break these ongoing connections.

The additions in this PR are the following subsequent steps to quarantining the instance:
1. Removing all external IP addresses associated to an instance, breaking off all ongoing connections.
1. Restoring the external IPs. If the IP address was static, it will be re-applied. Otherwise if it was ephemeral, an ephemeral address will be re-applied.