### PR TITLE
Change exponential backoff to calculated timeout for Snapshot S3 copy

### DIFF
--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -411,7 +411,7 @@ def CopyEBSSnapshotToS3(
   # and transfer rates (documented in cloud-forensics-utils/issues/354)
   snapshot_size = aws_account.ec2.GetSnapshotInfo(snapshot_id)['VolumeSize']
   percentiles = [0.25, 0.5, 0.85, 1.15, 1.5, 2.0]
-  transfer_speed = 150 # seconds per GB
+  transfer_speed = 60 # seconds per GB
   curr_wait = 0
   success = False
   prefix = '{0:s}/{1:s}/'.format(object_path, snapshot_id)

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -335,6 +335,7 @@ def CopyEBSSnapshotToS3(
 
   Raises:
     ResourceCreationError: If any dependent resource could not be created.
+    ResourceNotFoundError: If the snapshot ID cannot be found.
   """
 
   # Correct destination if necessary

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -417,6 +417,9 @@ def CopyEBSSnapshotToS3(
   prefix = '{0:s}/{1:s}/'.format(object_path, snapshot_id)
   files = ['image.bin', 'log.txt', 'hlog.txt', 'mlog.txt']
 
+  logger.info('Transfer expected to take {0:d} seconds'.
+    format(snapshot_size * transfer_speed))
+
   for percentile in percentiles:
     curr_step = int(percentile * snapshot_size * transfer_speed)
     logger.info('Waiting {0:d} seconds ({1:d} seconds total wait time) '

--- a/libcloudforensics/providers/aws/internal/ec2.py
+++ b/libcloudforensics/providers/aws/internal/ec2.py
@@ -672,3 +672,16 @@ class EC2:
       raise errors.ResourceCreationError(
         'Could not modify instance attributes: {0!s}'.format(
            exception), __name__) from exception
+
+  def GetSnapshotInfo(
+    self,
+    snapshot_id: str,
+    ) -> Dict[str, Any]:
+    """Get information about the snapshot.
+
+    Args:
+      snapshot_id (str): the snapshot id to fetch info for (snap-xxxxxx).
+    """
+    client = self.aws_account.ClientApi(common.EC2_SERVICE)
+    return Dict(client.describe_snapshots(SnapshotIds=[snapshot_id])\
+      ['Snapshots'][0])

--- a/libcloudforensics/providers/aws/internal/ec2.py
+++ b/libcloudforensics/providers/aws/internal/ec2.py
@@ -683,5 +683,5 @@ class EC2:
       snapshot_id (str): the snapshot id to fetch info for (snap-xxxxxx).
     """
     client = self.aws_account.ClientApi(common.EC2_SERVICE)
-    return Dict(client.describe_snapshots(SnapshotIds=[snapshot_id])\
+    return dict(client.describe_snapshots(SnapshotIds=[snapshot_id])\
       ['Snapshots'][0])

--- a/libcloudforensics/providers/aws/internal/ec2.py
+++ b/libcloudforensics/providers/aws/internal/ec2.py
@@ -660,6 +660,9 @@ class EC2:
     Args:
       instance_id (str): The instance ID (i-xxxxxx)
       sg_id (str): The Security Group ID (sg-xxxxxx)
+
+    Raises:
+      ResourceNotFoundError: If the snapshot ID cannot be found.
     """
     client = self.aws_account.ClientApi(common.EC2_SERVICE)
 
@@ -683,5 +686,10 @@ class EC2:
       snapshot_id (str): the snapshot id to fetch info for (snap-xxxxxx).
     """
     client = self.aws_account.ClientApi(common.EC2_SERVICE)
-    return dict(client.describe_snapshots(SnapshotIds=[snapshot_id])\
-      ['Snapshots'][0])
+    try:
+      response = client.describe_snapshots(SnapshotIds=[snapshot_id])
+    except client.exceptions.ClientError as exception:
+      raise errors.ResourceNotFoundError(
+          'Could not find snapshot {0:s}: {1!s}'.format(
+              snapshot_id, exception), __name__) from exception
+    return dict(response['Snapshots'][0])


### PR DESCRIPTION
Within the AWS EBS snapshot copy to S3 operation, change the exponential backoff (10.5 mins total) to a calculated set of timings based on the snapshot size and the transfer rates from EC2->S3. 

Closes #354