### PR TITLE
Adjusted ebs snapshot s3 copy to wait for the instance health check

### DIFF
--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -405,7 +405,7 @@ def CopyEBSSnapshotToS3(
     userdata=startup_script,
     instance_profile=instance_profile_arn,
     terminate_on_shutdown=True,
-    wait_for_health_checks=False
+    wait_for_health_checks=True
   )
 
   # Calculate the times we should check for completion based on volume size


### PR DESCRIPTION
This allows more wait time for the instance to start before checking for success starts. 