### PR TITLE
Revert 358, add wait for copy instance launch

### DIFF
--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -405,8 +405,11 @@ def CopyEBSSnapshotToS3(
     userdata=startup_script,
     instance_profile=instance_profile_arn,
     terminate_on_shutdown=True,
-    wait_for_health_checks=True
+    wait_for_health_checks=False
   )
+
+  logger.info('Pausing 60 seconds while copy instance launches')
+  sleep(60)
 
   # Calculate the times we should check for completion based on volume size
   # and transfer rates (documented in cloud-forensics-utils/issues/354)

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -405,7 +405,7 @@ def CopyEBSSnapshotToS3(
     userdata=startup_script,
     instance_profile=instance_profile_arn,
     terminate_on_shutdown=True,
-    wait_for_health_checks=True
+    wait_for_health_checks=False
   )
 
   logger.info('Pausing 60 seconds while copy instance launches')

--- a/libcloudforensics/providers/aws/forensics.py
+++ b/libcloudforensics/providers/aws/forensics.py
@@ -405,7 +405,7 @@ def CopyEBSSnapshotToS3(
     userdata=startup_script,
     instance_profile=instance_profile_arn,
     terminate_on_shutdown=True,
-    wait_for_health_checks=False
+    wait_for_health_checks=True
   )
 
   # Calculate the times we should check for completion based on volume size


### PR DESCRIPTION
Previous PR did not fix E2E failure in jenkins - On small snapshots the instance finishes the copy and terminates before the health checks pass, causing the health check wait to time out.

Revert that PR, and add a wait time for instance launch. 