### PR TITLE
Update .pylintrc

### DIFF
--- a/.github/workflows/pylint_and_mypy.yml
+++ b/.github/workflows/pylint_and_mypy.yml
@@ -26,4 +26,4 @@ jobs:
         pylint tests libcloudforensics tools
     - name: Run mypy on all *.py files
       run: |
-        mypy --ignore-missing-imports --strict --no-warn-unused-ignores -p tests -p libcloudforensics -p tools
+        mypy --ignore-missing-imports --strict --no-warn-unused-ignores -m tests -m libcloudforensics -m tools

--- a/.pylintrc
+++ b/.pylintrc
@@ -53,6 +53,7 @@ confidence=
 disable=
     assignment-from-none,
     bad-inline-option,
+    consider-using-f-string,
     deprecated-pragma,
     duplicate-code,
     eq-without-hash,


### PR DESCRIPTION
Disables new pylint error that does not correspond to the [log2timeline style guide](https://github.com/log2timeline/l2tdocs/blob/main/process/Style-guide.md#strings).