### PR TITLE
GKE integrate NetworkPolicy check to quarantining process

### DIFF
--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Classes for displaying prompts to a user and running their choices."""
 import abc
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Tuple
 
 from libcloudforensics import logging_utils
 
@@ -31,7 +31,7 @@ def _Strikethrough(text: str) -> str:
   Returns:
     str: The given text with strikethrough codes.
   """
-  return ''.join('{0:s}\u0336'.format(char) for char in text)
+  return ''.join('\u0336{0:s}'.format(char) for char in text)
 
 
 class PromptOption:
@@ -45,7 +45,7 @@ class PromptOption:
       self,
       text: str,
       *functions: Callable[[], None],
-      disable_options: Optional[List['PromptOption']] = None) -> None:
+      disable_options: Optional[List[Tuple['PromptOption', str]]] = None) -> None:
     """Builds a PromptOption.
 
     Args:
@@ -57,7 +57,7 @@ class PromptOption:
     """
     self._text = text
     self._functions = functions
-    self._disabled = False
+    self._disabled_reason = None
     self._selected = False
     self._disable_options = disable_options or []
 
@@ -66,9 +66,9 @@ class PromptOption:
     """The text description of this PromptOption."""
     return self._text
 
-  def Disable(self) -> None:
+  def Disable(self, reason: str) -> None:
     """Disables this prompt."""
-    self._disabled = True
+    self._disabled_reason = reason
 
   def IsDisabled(self) -> bool:
     """Returns True if this prompt is disabled, false otherwise.
@@ -76,12 +76,12 @@ class PromptOption:
     Returns:
       bool: True if this prompt is disabled, false otherwise.
     """
-    return self._disabled
+    return self._disabled_reason is not None
 
   def Select(self) -> None:
     """Selects this prompt, disabling dependent prompts."""
-    for option in self._disable_options:
-      option.Disable()
+    for option, reason in self._disable_options:
+      option.Disable(reason)
     self._selected = True
 
   def IsSelected(self) -> bool:
@@ -95,8 +95,8 @@ class PromptOption:
   def ToQuestion(self) -> str:
     """The text to be displayed for this prompt option."""
     question = '{0:s}?'.format(self._text)
-    if self._disabled:
-      question = _Strikethrough(question)
+    if self.IsDisabled():
+      question = '{0:s} ({1:s})'.format(_Strikethrough(question), self._disabled_reason)
     return question
 
   def Execute(self) -> None:

--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -21,6 +21,7 @@ from libcloudforensics import logging_utils
 logging_utils.SetUpLogger(__name__, no_newline=True)
 logger = logging_utils.GetLogger(__name__)
 
+DisableList = List[Tuple['PromptOption', str]]
 
 def _Strikethrough(text: str) -> str:
   """Returns given text with strikethrough codes after each character.
@@ -45,15 +46,17 @@ class PromptOption:
       self,
       text: str,
       *functions: Callable[[], None],
-      disable_options: Optional[List[Tuple['PromptOption', str]]] = None) -> None:
+      disable_options: Optional[DisableList] = None) -> None:
     """Builds a PromptOption.
 
     Args:
       text (str): The text description this prompt option.
       functions (Callable[[], None]): The underlying functions of this prompt
           option to be called upon execution.
-      disable_options (List[PromptOption]): Optional. List of prompt options
-          to disable upon selection of this prompt option.
+      disable_options (DisableList): Optional. List of prompt options
+          to disable upon selection of this prompt option. This is a list of
+          tuples, with a prompt option to disable and an associated reason for
+          disabling.
     """
     self._text = text
     self._functions = functions
@@ -96,7 +99,8 @@ class PromptOption:
     """The text to be displayed for this prompt option."""
     question = '{0:s}?'.format(self._text)
     if self.IsDisabled():
-      question = '{0:s} ({1:s})'.format(_Strikethrough(question), self._disabled_reason)
+      question = '{0:s} ({1:s})'.format(
+          _Strikethrough(question), self._disabled_reason)
     return question
 
   def Execute(self) -> None:

--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -60,7 +60,7 @@ class PromptOption:
     """
     self._text = text
     self._functions = functions
-    self._disabled_reason = None
+    self._disabled_reason = None  # type: Optional[str]
     self._selected = False
     self._disable_options = disable_options or []
 

--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -70,7 +70,11 @@ class PromptOption:
     return self._text
 
   def Disable(self, reason: str) -> None:
-    """Disables this prompt."""
+    """Disables this prompt.
+
+    Args:
+      reason (str): The reason for disabling this prompt.
+    """
     self._disabled_reason = reason
 
   def IsDisabled(self) -> bool:

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -518,7 +518,7 @@ def QuarantineGKEWorkload(project_id: str,
     for node in workload_nodes:
       logger.info(
           'Cordoning Kubernetes node {0:s} from {1:s} '
-          'deployment...'.format(node, k8s_workload.name))
+          'deployment...'.format(node.name, k8s_workload.name))
       node.Cordon()
 
   def AbandonNodes() -> None:

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -512,6 +512,7 @@ def QuarantineGKEWorkload(project_id: str,
   groups_by_instance = compute_project.ListMIGSByInstanceName(zone)
 
   workload_nodes = k8s_workload.GetCoveredNodes()
+  workload_pods = k8s_workload.GetCoveredPods()
 
   def CordonNodes() -> None:
     """Cordons the compromised nodes."""
@@ -540,7 +541,7 @@ def QuarantineGKEWorkload(project_id: str,
     logger.info(
         'Creating deny-all NetworkPolicy for {0:s} '
         'workload...'.format(workload_id))
-    mitigation.CreateDenyAllNetworkPolicyForWorkload(k8s_cluster, k8s_workload)
+    mitigation.IsolatePodsWithNetworkPolicy(k8s_cluster, workload_pods)
 
   def DrainNodes() -> None:
     """Drains the workload nodes from other pods."""

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -511,7 +511,7 @@ def QuarantineGKEWorkload(project_id: str,
   compute_project = compute.GoogleCloudCompute(project_id)
   groups_by_instance = compute_project.ListMIGSByInstanceName(zone)
 
-  workload_nodes = {pod.GetNode() for pod in k8s_workload.GetCoveredPods()}
+  workload_nodes = k8s_workload.GetCoveredNodes()
 
   def CordonNodes() -> None:
     """Cordons the compromised nodes."""
@@ -569,30 +569,39 @@ def QuarantineGKEWorkload(project_id: str,
 
   # Second prompt options, defined afterwards so that we can link disables
   preserve_delete = prompts.PromptOption(
-      'Preserve evidence and delete workload',
-      OrphanPods,
-      disable_options=[isolate_pods])
+      'Preserve evidence and delete workload', OrphanPods)
   preserve_preserve = prompts.PromptOption(
       'Preserve evidence and preserve workload',
       # No functions are called when this option is selected, a multi prompt
       # was favored over a yes/no prompt for clarity
-      disable_options=[isolate_nodes, isolate_nodes_and_pods])
+      disable_options=[
+          (
+              isolate_nodes,
+              'Isolating nodes will cause workload pods to appear elsewhere.'),
+          (
+              isolate_nodes_and_pods,
+              'Isolating nodes will cause workload pods to appear elsewhere.')
+      ])
 
   prompt_sequence = prompts.PromptSequence(
       prompts.YesNoPrompt(
           prompts.PromptOption(
-              'Abandon nodes from managed instance group', AbandonNodes)),
-      prompts.YesNoPrompt(prompts.PromptOption('Cordon nodes', CordonNodes)),
+              'Abandon nodes from managed instance group', AbandonNodes),
+          default_yes=True),
+      prompts.YesNoPrompt(
+          prompts.PromptOption('Cordon nodes', CordonNodes), default_yes=True),
       prompts.MultiPrompt([
           preserve_delete,
           preserve_preserve,
       ]),
-      prompts.MultiPrompt([
-          isolate_nodes,
-          isolate_pods,
-          isolate_nodes_and_pods
-      ]),
+      prompts.MultiPrompt([isolate_nodes, isolate_pods,
+                           isolate_nodes_and_pods]),
   )
+
+  # If network policy is disabled, disable the isolate_pods prompt because
+  # it will have no effect
+  if not gke_cluster.IsNetworkPolicyEnabled():
+    isolate_pods.Disable('NetworkPolicy not enabled.')
 
   prompt_sequence.Run(summarize=True)
 

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -30,7 +30,7 @@ def DrainWorkloadNodesFromOtherPods(
         to prevent pods from appearing on the nodes again as it will be marked
         as unschedulable. Defaults to True.
   """
-  nodes = set(pod.GetNode() for pod in workload.GetCoveredPods())
+  nodes = workload.GetCoveredNodes()
   if cordon:
     for node in nodes:
       node.Cordon()

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Mitigation functions to be used in end-to-end functionality."""
+from typing import List, Optional
 
+from libcloudforensics.providers.kubernetes import base
 from libcloudforensics.providers.kubernetes import cluster as k8s
 from libcloudforensics.providers.kubernetes import netpol
 from libcloudforensics.providers.kubernetes import workloads
@@ -38,34 +40,41 @@ def DrainWorkloadNodesFromOtherPods(
     node.Drain(lambda pod: not workload.IsCoveringPod(pod))
 
 
-def CreateDenyAllNetworkPolicyForWorkload(
+def IsolatePodsWithNetworkPolicy(
     cluster: k8s.K8sCluster,
-    workload: workloads.K8sWorkload) -> netpol.K8sDenyAllNetworkPolicy:
-  """Isolates a workload's pods via a deny all network policy.
+    pods: List[base.K8sPod]) -> Optional[netpol.K8sDenyAllNetworkPolicy]:
+  """Isolates pods via a deny-all NetworkPolicy.
 
   **Warning:** It is the caller's responsibility to make sure that Kubernetes
   NetworkPolicy is enabled for their cluster, via their cloud provider's API.
 
   Args:
     cluster (k8s.K8sCluster): The cluster in which to create the deny-all
-        policy, and subsequently patch existing policies
-    workload (workloads.K8sWorkload): The workload in whose namespace the
-        deny all network policy will be created, and whose pods will be tagged
-        to be selected by the deny all network policy.
+        policy.
+    pods (List[base.K8sPod]): The pods to patch with the labels of the created
+        deny-all NetworkPolicy.
 
   Returns:
-    netpol.K8sDenyAllNetworkPolicy: The deny all network policy that was
-        created to isolate the workload's pods.
+    netpol.K8sDenyAllNetworkPolicy: Optional. The deny-all network policy that
+        was created to isolate the pods. If no pods were supplied, None is
+        returned.
+
+  Raises:
+    ValueError: If the pods are not in the same namespace.
   """
+  if not pods:
+    return None
+  if any(pod.namespace != pods[0].namespace for pod in pods):
+    raise ValueError('Supplied pods are not in the same namespace.')
   # First create the NetworkPolicy in the workload's namespace
-  deny_all_policy = cluster.DenyAllNetworkPolicy(workload.namespace)
+  deny_all_policy = cluster.DenyAllNetworkPolicy(pods[0].namespace)
   deny_all_policy.Create()
   # Tag the pods covered by the workload with the selecting label of the
-  # deny all NetworkPolicy
-  for pod in workload.GetCoveredPods():
+  # deny-all NetworkPolicy
+  for pod in pods:
     pod.AddLabels(deny_all_policy.labels)
   # For all other policies, specify that they are not selecting the pods
-  # that are selected by the deny all policy
-  # TODO: Patch other policies (in same namespace?)
+  # that are selected by the deny-all policy
+  # TODO: Patch other policies
 
   return deny_all_policy

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -35,7 +35,7 @@ def DrainWorkloadNodesFromOtherPods(
     for node in nodes:
       node.Cordon()
   for node in nodes:
-    node.Drain(lambda p: not workload.IsCoveringPod(p))
+    node.Drain(lambda pod: not workload.IsCoveringPod(pod))
 
 
 def CreateDenyAllNetworkPolicyForWorkload(
@@ -43,9 +43,12 @@ def CreateDenyAllNetworkPolicyForWorkload(
     workload: workloads.K8sWorkload) -> netpol.K8sDenyAllNetworkPolicy:
   """Isolates a workload's pods via a deny all network policy.
 
+  **Warning:** It is the caller's responsibility to make sure that Kubernetes
+  NetworkPolicy is enabled for their cluster, via their cloud provider's API.
+
   Args:
-    cluster (k8s.K8sCluster): The cluster in which to create the deny
-        all policy, and subsequently patch existing policies
+    cluster (k8s.K8sCluster): The cluster in which to create the deny-all
+        policy, and subsequently patch existing policies
     workload (workloads.K8sWorkload): The workload in whose namespace the
         deny all network policy will be created, and whose pods will be tagged
         to be selected by the deny all network policy.
@@ -54,7 +57,6 @@ def CreateDenyAllNetworkPolicyForWorkload(
     netpol.K8sDenyAllNetworkPolicy: The deny all network policy that was
         created to isolate the workload's pods.
   """
-  # TODO: Check that network policies are enabled
   # First create the NetworkPolicy in the workload's namespace
   deny_all_policy = cluster.DenyAllNetworkPolicy(workload.namespace)
   deny_all_policy.Create()

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -98,6 +98,18 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
         for pod in pods.items
     ]
 
+  def GetCoveredNodes(self) -> List[base.K8sNode]:
+    """Gets a list of Kubernetes nodes covered by this workload.
+
+    Returns:
+      List[base.K8sNode]: A list of pods covered by this workload.
+    """
+    nodes_by_name = {}  # type: Dict[str, base.K8sNode]
+    for pod in self.GetCoveredPods():
+      node = pod.GetNode()
+      nodes_by_name[node.name] = node
+    return list(nodes_by_name.values())
+
   def IsCoveringPod(self, pod: base.K8sPod) -> bool:
     """Determines whether a pod is covered by this workload.
 

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -102,7 +102,7 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
     """Gets a list of Kubernetes nodes covered by this workload.
 
     Returns:
-      List[base.K8sNode]: A list of pods covered by this workload.
+      List[base.K8sNode]: A list of nodes covered by this workload.
     """
     nodes_by_name = {}  # type: Dict[str, base.K8sNode]
     for pod in self.GetCoveredPods():


### PR DESCRIPTION
Primary reason for this PR is integrating a NetworkPolicy check to the quarantining process, i.e. disabling the `Isolate pods?` option appropriately.

Additionally, this PR adds a few small changes:
- To disable a `PromptOption`, a reason for disabling is now required
- Fix a bug in which a workload's nodes may appear twice, by introducing a `K8sWorkload.GetCoveredNodes` method
- Add workaround to pod isolation when deleting workload
- Add appropriate defaults to the yes/no prompt options
- Fix strikethrough function
- Fix wrong string argument