### PR TITLE
Kubernetes class restructure

### DIFF
--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Classes for displaying prompts to a user and running their choices."""
 import abc
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Tuple
 
 from libcloudforensics import logging_utils
 
@@ -31,7 +31,7 @@ def _Strikethrough(text: str) -> str:
   Returns:
     str: The given text with strikethrough codes.
   """
-  return ''.join('{0:s}\u0336'.format(char) for char in text)
+  return ''.join('\u0336{0:s}'.format(char) for char in text)
 
 
 class PromptOption:
@@ -45,7 +45,7 @@ class PromptOption:
       self,
       text: str,
       *functions: Callable[[], None],
-      disable_options: Optional[List['PromptOption']] = None) -> None:
+      disable_options: Optional[List[Tuple['PromptOption', str]]] = None) -> None:
     """Builds a PromptOption.
 
     Args:
@@ -57,7 +57,7 @@ class PromptOption:
     """
     self._text = text
     self._functions = functions
-    self._disabled = False
+    self._disabled_reason = None
     self._selected = False
     self._disable_options = disable_options or []
 
@@ -66,9 +66,9 @@ class PromptOption:
     """The text description of this PromptOption."""
     return self._text
 
-  def Disable(self) -> None:
+  def Disable(self, reason: str) -> None:
     """Disables this prompt."""
-    self._disabled = True
+    self._disabled_reason = reason
 
   def IsDisabled(self) -> bool:
     """Returns True if this prompt is disabled, false otherwise.
@@ -76,12 +76,12 @@ class PromptOption:
     Returns:
       bool: True if this prompt is disabled, false otherwise.
     """
-    return self._disabled
+    return self._disabled_reason is not None
 
   def Select(self) -> None:
     """Selects this prompt, disabling dependent prompts."""
-    for option in self._disable_options:
-      option.Disable()
+    for option, reason in self._disable_options:
+      option.Disable(reason)
     self._selected = True
 
   def IsSelected(self) -> bool:
@@ -95,8 +95,8 @@ class PromptOption:
   def ToQuestion(self) -> str:
     """The text to be displayed for this prompt option."""
     question = '{0:s}?'.format(self._text)
-    if self._disabled:
-      question = _Strikethrough(question)
+    if self.IsDisabled():
+      question = '{0:s} ({1:s})'.format(_Strikethrough(question), self._disabled_reason)
     return question
 
   def Execute(self) -> None:

--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -21,6 +21,7 @@ from libcloudforensics import logging_utils
 logging_utils.SetUpLogger(__name__, no_newline=True)
 logger = logging_utils.GetLogger(__name__)
 
+DisableList = List[Tuple['PromptOption', str]]
 
 def _Strikethrough(text: str) -> str:
   """Returns given text with strikethrough codes after each character.
@@ -45,15 +46,17 @@ class PromptOption:
       self,
       text: str,
       *functions: Callable[[], None],
-      disable_options: Optional[List[Tuple['PromptOption', str]]] = None) -> None:
+      disable_options: Optional[DisableList] = None) -> None:
     """Builds a PromptOption.
 
     Args:
       text (str): The text description this prompt option.
       functions (Callable[[], None]): The underlying functions of this prompt
           option to be called upon execution.
-      disable_options (List[PromptOption]): Optional. List of prompt options
-          to disable upon selection of this prompt option.
+      disable_options (DisableList): Optional. List of prompt options
+          to disable upon selection of this prompt option. This is a list of
+          tuples, with a prompt option to disable and an associated reason for
+          disabling.
     """
     self._text = text
     self._functions = functions
@@ -96,7 +99,8 @@ class PromptOption:
     """The text to be displayed for this prompt option."""
     question = '{0:s}?'.format(self._text)
     if self.IsDisabled():
-      question = '{0:s} ({1:s})'.format(_Strikethrough(question), self._disabled_reason)
+      question = '{0:s} ({1:s})'.format(
+          _Strikethrough(question), self._disabled_reason)
     return question
 
   def Execute(self) -> None:

--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -60,7 +60,7 @@ class PromptOption:
     """
     self._text = text
     self._functions = functions
-    self._disabled_reason = None
+    self._disabled_reason = None  # type: Optional[str]
     self._selected = False
     self._disable_options = disable_options or []
 

--- a/libcloudforensics/prompts.py
+++ b/libcloudforensics/prompts.py
@@ -70,7 +70,11 @@ class PromptOption:
     return self._text
 
   def Disable(self, reason: str) -> None:
-    """Disables this prompt."""
+    """Disables this prompt.
+
+    Args:
+      reason (str): The reason for disabling this prompt.
+    """
     self._disabled_reason = reason
 
   def IsDisabled(self) -> bool:

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -501,24 +501,22 @@ def QuarantineGKEWorkload(project_id: str,
     namespace (str): The Kubernetes namespace of the workload (e.g. 'default').
     workload_id (str): The name of the workload.
   """
-  gke_cluster = gke.GkeCluster(project_id, zone, cluster_id)
-  k8s_cluster = gke_cluster.GetK8sCluster()
-
-  k8s_workload = k8s_cluster.GetDeployment(workload_id, namespace)
+  cluster = gke.GkeCluster(project_id, zone, cluster_id)
+  workload = cluster.GetDeployment(workload_id, namespace)
 
   # Build a dict to find a managed instance group via an instance name,
   # so that we can instance.AbandonFromMIG
   compute_project = compute.GoogleCloudCompute(project_id)
   groups_by_instance = compute_project.ListMIGSByInstanceName(zone)
 
-  workload_nodes = k8s_workload.GetCoveredNodes()
+  workload_nodes = workload.GetCoveredNodes()
 
   def CordonNodes() -> None:
     """Cordons the compromised nodes."""
     for node in workload_nodes:
       logger.info(
           'Cordoning Kubernetes node {0:s} from {1:s} '
-          'deployment...'.format(node, k8s_workload.name))
+          'deployment...'.format(node, workload.name))
       node.Cordon()
 
   def AbandonNodes() -> None:
@@ -540,18 +538,18 @@ def QuarantineGKEWorkload(project_id: str,
     logger.info(
         'Creating deny-all NetworkPolicy for {0:s} '
         'workload...'.format(workload_id))
-    mitigation.CreateDenyAllNetworkPolicyForWorkload(k8s_cluster, k8s_workload)
+    mitigation.CreateDenyAllNetworkPolicyForWorkload(cluster, workload)
 
   def DrainNodes() -> None:
     """Drains the workload nodes from other pods."""
     logger.info('Draining workload nodes from other pods...')
-    mitigation.DrainWorkloadNodesFromOtherPods(k8s_workload, cordon=False)
+    mitigation.DrainWorkloadNodesFromOtherPods(workload, cordon=False)
 
   def OrphanPods() -> None:
     """Orphans the pods of the workload."""
     logger.info(
         'Orphaning Kubernetes workload {0:s}\'s pods...'.format(workload_id))
-    k8s_workload.OrphanPods()
+    workload.OrphanPods()
 
   def FirewallNodes() -> None:
     """Puts each node from the workload into network quarantine."""
@@ -600,7 +598,7 @@ def QuarantineGKEWorkload(project_id: str,
 
   # If network policy is disabled, disable the isolate_pods prompt because
   # it will have no effect
-  if not gke_cluster.IsNetworkPolicyEnabled():
+  if not cluster.IsNetworkPolicyEnabled():
     isolate_pods.Disable('NetworkPolicy not enabled.')
 
   prompt_sequence.Run(summarize=True)

--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -511,7 +511,7 @@ def QuarantineGKEWorkload(project_id: str,
   compute_project = compute.GoogleCloudCompute(project_id)
   groups_by_instance = compute_project.ListMIGSByInstanceName(zone)
 
-  workload_nodes = {pod.GetNode() for pod in k8s_workload.GetCoveredPods()}
+  workload_nodes = k8s_workload.GetCoveredNodes()
 
   def CordonNodes() -> None:
     """Cordons the compromised nodes."""
@@ -569,30 +569,39 @@ def QuarantineGKEWorkload(project_id: str,
 
   # Second prompt options, defined afterwards so that we can link disables
   preserve_delete = prompts.PromptOption(
-      'Preserve evidence and delete workload',
-      OrphanPods,
-      disable_options=[isolate_pods])
+      'Preserve evidence and delete workload', OrphanPods)
   preserve_preserve = prompts.PromptOption(
       'Preserve evidence and preserve workload',
       # No functions are called when this option is selected, a multi prompt
       # was favored over a yes/no prompt for clarity
-      disable_options=[isolate_nodes, isolate_nodes_and_pods])
+      disable_options=[
+          (
+              isolate_nodes,
+              'Isolating nodes will cause workload pods to appear elsewhere.'),
+          (
+              isolate_nodes_and_pods,
+              'Isolating nodes will cause workload pods to appear elsewhere.')
+      ])
 
   prompt_sequence = prompts.PromptSequence(
       prompts.YesNoPrompt(
           prompts.PromptOption(
-              'Abandon nodes from managed instance group', AbandonNodes)),
-      prompts.YesNoPrompt(prompts.PromptOption('Cordon nodes', CordonNodes)),
+              'Abandon nodes from managed instance group', AbandonNodes),
+          default_yes=True),
+      prompts.YesNoPrompt(
+          prompts.PromptOption('Cordon nodes', CordonNodes), default_yes=True),
       prompts.MultiPrompt([
           preserve_delete,
           preserve_preserve,
       ]),
-      prompts.MultiPrompt([
-          isolate_nodes,
-          isolate_pods,
-          isolate_nodes_and_pods
-      ]),
+      prompts.MultiPrompt([isolate_nodes, isolate_pods,
+                           isolate_nodes_and_pods]),
   )
+
+  # If network policy is disabled, disable the isolate_pods prompt because
+  # it will have no effect
+  if not gke_cluster.IsNetworkPolicyEnabled():
+    isolate_pods.Disable('NetworkPolicy not enabled.')
 
   prompt_sequence.Run(summarize=True)
 

--- a/libcloudforensics/providers/gcp/internal/gke.py
+++ b/libcloudforensics/providers/gcp/internal/gke.py
@@ -45,7 +45,7 @@ class GoogleKubernetesEngine:
     return common.CreateService('container', self.GKE_API_VERSION)
 
 
-class GkeCluster(GoogleKubernetesEngine):
+class GkeCluster(cluster.K8sCluster, GoogleKubernetesEngine):
   """Class to call GKE and Kubernetes APIs on a GKE resource.
 
   https://cloud.google.com/kubernetes-engine/docs/reference/rest
@@ -68,6 +68,7 @@ class GkeCluster(GoogleKubernetesEngine):
     self.project_id = project_id
     self.zone = zone
     self.cluster_id = cluster_id
+    cluster.K8sCluster.__init__(self, self._GetK8sApiClient())
 
   @property
   def name(self) -> str:
@@ -170,15 +171,6 @@ class GkeCluster(GoogleKubernetesEngine):
         raise KeyError('Nested object was not a dict.')
     return current
 
-  def GetK8sCluster(self) -> cluster.K8sCluster:
-    """Returns the Kubernetes cluster of this GKE cluster.
-
-    Returns:
-      cluster.K8sCluster: The Kubernetes cluster matching this GKE cluster,
-          exposing methods to call the Kubernetes API.
-    """
-    return cluster.K8sCluster(self._GetK8sApiClient())
-
   def IsWorkloadIdentityEnabled(self) -> bool:
     """Returns whether the workload identity is enabled.
 
@@ -204,9 +196,5 @@ class GkeCluster(GoogleKubernetesEngine):
             'disable-legacy-endpoints') == 'true')
 
   def IsNetworkPolicyEnabled(self) -> bool:
-    """Returns whether network policies are enabled.
-
-    Returns:
-      bool: True if network policies are enabled, False otherwise.
-    """
+    """Override of abstract method."""
     return bool(self._GetValue('networkPolicy', 'enabled', default=False))

--- a/libcloudforensics/providers/kubernetes/base.py
+++ b/libcloudforensics/providers/kubernetes/base.py
@@ -212,6 +212,7 @@ class K8sNode(K8sResource):
         if address.type == 'InternalIP'
     ]
 
+
 class K8sWorkload(K8sNamespacedResource):
   """Abstract class representing Kubernetes workloads."""
 
@@ -248,6 +249,7 @@ class K8sWorkload(K8sNamespacedResource):
     Returns:
       bool: True if the pod is covered this workload, False otherwise.
     """
+
 
 class K8sPod(K8sWorkload):
   """Class representing a Kubernetes pod.

--- a/libcloudforensics/providers/kubernetes/base.py
+++ b/libcloudforensics/providers/kubernetes/base.py
@@ -188,7 +188,7 @@ class K8sNode(K8sResource):
         for pod in pods.items
     ]
 
-  def ExternalIPs(self) -> List[str]:
+  def ExternalIps(self) -> List[str]:
     """Returns the external IPs of this node.
 
     Returns:
@@ -200,7 +200,7 @@ class K8sNode(K8sResource):
         if address.type == 'ExternalIP'
     ]
 
-  def InternalIPs(self) -> List[str]:
+  def InternalIps(self) -> List[str]:
     """Returns the internal IPs of this node.
 
     Returns:
@@ -212,12 +212,56 @@ class K8sNode(K8sResource):
         if address.type == 'InternalIP'
     ]
 
+class K8sWorkload(K8sNamespacedResource):
+  """Abstract class representing Kubernetes workloads."""
 
-class K8sPod(K8sNamespacedResource):
+  @abc.abstractmethod
+  def GetCoveredPods(self) -> List['K8sPod']:
+    """Gets a list of Kubernetes pods covered by this workload.
+
+    Returns:
+      List[K8sPod]: A list of pods covered by this workload.
+    """
+
+  def GetCoveredNodes(self) -> List[K8sNode]:
+    """Gets a list of Kubernetes nodes covered by this workload.
+
+    Returns:
+      List[K8sNode]: A list of nodes covered by this workload.
+    """
+    nodes_by_name = {}  # type: Dict[str, K8sNode]
+    for pod in self.GetCoveredPods():
+      node = pod.GetNode()
+      nodes_by_name[node.name] = node
+    return list(nodes_by_name.values())
+
+  @abc.abstractmethod
+  def IsCoveringPod(self, pod: 'K8sPod') -> bool:
+    """Determines whether a pod is covered by this workload.
+
+    This function checks if this workload's pod match labels are a subset of the
+    given pod's labels.
+
+    Args:
+      pod (K8sPod): The pod to be checked with the labels of this workload.
+
+    Returns:
+      bool: True if the pod is covered this workload, False otherwise.
+    """
+
+class K8sPod(K8sWorkload):
   """Class representing a Kubernetes pod.
 
   https://kubernetes.io/docs/concepts/workloads/pods/
   """
+
+  def GetCoveredPods(self) -> List['K8sPod']:
+    """Override of abstract method"""
+    return [self]
+
+  def IsCoveringPod(self, pod: 'K8sPod') -> bool:
+    """Override of abstract method."""
+    return self.Read() == pod.Read()
 
   def Read(self) -> client.V1Pod:
     """Override of abstract method."""

--- a/libcloudforensics/providers/kubernetes/base.py
+++ b/libcloudforensics/providers/kubernetes/base.py
@@ -263,7 +263,7 @@ class K8sPod(K8sWorkload):
 
   def IsCoveringPod(self, pod: 'K8sPod') -> bool:
     """Override of abstract method."""
-    return self.Read() == pod.Read()
+    return bool(self.Read() == pod.Read())
 
   def Read(self) -> client.V1Pod:
     """Override of abstract method."""

--- a/libcloudforensics/providers/kubernetes/cluster.py
+++ b/libcloudforensics/providers/kubernetes/cluster.py
@@ -152,6 +152,9 @@ class K8sCluster(base.K8sClient):
     """
     return services.K8sService(self._api_client, service_id, namespace)
 
+  def GetPod(self, pod_name: str, namespace: str) -> base.K8sPod:
+    return base.K8sPod(self._api_client, pod_name, namespace)
+
   def DenyAllNetworkPolicy(
       self, namespace: str) -> netpol.K8sDenyAllNetworkPolicy:
     """Gets a deny-all network policy for the cluster.

--- a/libcloudforensics/providers/kubernetes/cluster.py
+++ b/libcloudforensics/providers/kubernetes/cluster.py
@@ -42,7 +42,7 @@ class K8sCluster(base.K8sClient, metaclass=abc.ABCMeta):
       api_client (client.ApiClient): The API client to the Kubernetes cluster.
     """
     super().__init__(api_client)
-    self.__AuthorizationCheck()
+    self._AuthorizationCheck()
 
   def ListPods(self, namespace: Optional[str] = None) -> List[base.K8sPod]:
     """Lists the pods of this cluster, possibly filtering for a namespace.
@@ -109,7 +109,7 @@ class K8sCluster(base.K8sClient, metaclass=abc.ABCMeta):
         for policy in policies
     ]
 
-  def __AuthorizationCheck(self) -> None:
+  def _AuthorizationCheck(self) -> None:
     """Checks the authorization of this cluster's API client.
 
     Performs a check as per `kubectl auth can-i '*' '*' --all-namespaces`,

--- a/libcloudforensics/providers/kubernetes/cluster.py
+++ b/libcloudforensics/providers/kubernetes/cluster.py
@@ -152,7 +152,27 @@ class K8sCluster(base.K8sClient):
     """
     return services.K8sService(self._api_client, service_id, namespace)
 
+  def GetNode(self, node_name: str) -> base.K8sNode:
+    """Gets a node object in this cluster.
+
+    Args:
+      node_name (str): The name of the node.
+
+    Returns:
+      base.K8sNode: The matching node object.
+    """
+    return base.K8sNode(self._api_client, node_name)
+
   def GetPod(self, pod_name: str, namespace: str) -> base.K8sPod:
+    """Gets a pod object in this cluster.
+
+    Args:
+      pod_name (str): The name of the pod.
+      namespace (str): The namespace of the pod.
+
+    Returns:
+      base.K8sPod: The matching pod object.
+    """
     return base.K8sPod(self._api_client, pod_name, namespace)
 
   def DenyAllNetworkPolicy(

--- a/libcloudforensics/providers/kubernetes/cluster.py
+++ b/libcloudforensics/providers/kubernetes/cluster.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Kubernetes cluster class, starting point for Kubernetes API calls."""
+import abc
 from typing import Optional, List
 
 from kubernetes import client
@@ -27,8 +28,8 @@ logging_utils.SetUpLogger(__name__)
 logger = logging_utils.GetLogger(__name__)
 
 
-class K8sCluster(base.K8sClient):
-  """Class representing a Kubernetes cluster."""
+class K8sCluster(base.K8sClient, metaclass=abc.ABCMeta):
+  """Abstract class representing a Kubernetes cluster."""
 
   def __init__(self, api_client: client.ApiClient) -> None:
     """Creates a K8sCluster object, checking the API client's authorization.
@@ -190,3 +191,11 @@ class K8sCluster(base.K8sClient):
           the creation method on the object to create the policy.
     """
     return netpol.K8sDenyAllNetworkPolicy(self._api_client, namespace)
+
+  @abc.abstractmethod
+  def IsNetworkPolicyEnabled(self):
+    """Returns whether network policies are enabled.
+
+    Returns:
+      bool: True if network policies are enabled, False otherwise.
+    """

--- a/libcloudforensics/providers/kubernetes/cluster.py
+++ b/libcloudforensics/providers/kubernetes/cluster.py
@@ -193,7 +193,7 @@ class K8sCluster(base.K8sClient, metaclass=abc.ABCMeta):
     return netpol.K8sDenyAllNetworkPolicy(self._api_client, namespace)
 
   @abc.abstractmethod
-  def IsNetworkPolicyEnabled(self):
+  def IsNetworkPolicyEnabled(self) -> bool:
     """Returns whether network policies are enabled.
 
     Returns:

--- a/libcloudforensics/providers/kubernetes/enumerations/base.py
+++ b/libcloudforensics/providers/kubernetes/enumerations/base.py
@@ -27,7 +27,6 @@ from libcloudforensics.providers.kubernetes import cluster
 from libcloudforensics.providers.kubernetes import container
 from libcloudforensics.providers.kubernetes import services
 from libcloudforensics.providers.kubernetes import volume
-from libcloudforensics.providers.kubernetes import workloads
 
 logging_utils.SetUpLogger(__name__)
 logger = logging_utils.GetLogger(__name__)

--- a/libcloudforensics/providers/kubernetes/enumerations/base.py
+++ b/libcloudforensics/providers/kubernetes/enumerations/base.py
@@ -347,8 +347,8 @@ class NodeEnumeration(Enumeration[base.K8sNode]):
     """Method override."""
     info.update({
         'Name': self._object.name,
-        'ExternalIPs': self._object.ExternalIPs(),
-        'InternalIPs': self._object.InternalIPs(),
+        'ExternalIPs': self._object.ExternalIps(),
+        'InternalIPs': self._object.InternalIps(),
     })
 
 
@@ -367,7 +367,7 @@ class ClusterEnumeration(Enumeration[cluster.K8sCluster]):
       yield NodeEnumeration(node)
 
 
-class WorkloadEnumeration(Enumeration[workloads.K8sWorkload]):
+class WorkloadEnumeration(Enumeration[base.K8sWorkload]):
   """Enumeration of a Kubernetes workload."""
 
   @property

--- a/libcloudforensics/providers/kubernetes/enumerations/gcp.py
+++ b/libcloudforensics/providers/kubernetes/enumerations/gcp.py
@@ -30,7 +30,7 @@ class GkeClusterEnumeration(base.Enumeration[gke.GkeCluster]):
   def _Children(
       self, namespace: Optional[str] = None) -> Iterable[base.Enumeration[Any]]:
     """Method override."""
-    yield base.ClusterEnumeration(self._object.GetK8sCluster())
+    yield base.ClusterEnumeration(self._object)
 
   def _Populate(self, info: Dict[str, Any], warnings: Dict[str, Any]) -> None:
     """Method override."""

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -54,6 +54,9 @@ def CreateDenyAllNetworkPolicyForWorkload(
   Returns:
     netpol.K8sDenyAllNetworkPolicy: The deny all network policy that was
         created to isolate the workload's pods.
+
+  Raises:
+    errors.OperationFailedError: If NetworkPolicy is not enabled in the cluster.
   """
   if not cluster.IsNetworkPolicyEnabled():
     raise errors.OperationFailedError(

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Mitigation functions to be used in end-to-end functionality."""
-
+from libcloudforensics.providers.kubernetes import base
 from libcloudforensics.providers.kubernetes import cluster as k8s
 from libcloudforensics.providers.kubernetes import netpol
 from libcloudforensics.providers.kubernetes import workloads
 
 
 def DrainWorkloadNodesFromOtherPods(
-    workload: workloads.K8sWorkload, cordon: bool = True) -> None:
+    workload: base.K8sWorkload, cordon: bool = True) -> None:
   """Drains a workload's nodes from non-workload pods.
 
   Args:
-    workload (workloads.K8sWorkload): The workload for which nodes
+    workload (base.K8sWorkload): The workload for which nodes
         must be drained from pods that are not covered by the workload.
     cordon (bool): Optional. Whether or not to cordon the nodes before draining,
         to prevent pods from appearing on the nodes again as it will be marked
@@ -40,7 +40,7 @@ def DrainWorkloadNodesFromOtherPods(
 
 def CreateDenyAllNetworkPolicyForWorkload(
     cluster: k8s.K8sCluster,
-    workload: workloads.K8sWorkload) -> netpol.K8sDenyAllNetworkPolicy:
+    workload: base.K8sWorkload) -> netpol.K8sDenyAllNetworkPolicy:
   """Isolates a workload's pods via a deny all network policy.
 
   **Warning:** It is the caller's responsibility to make sure that Kubernetes
@@ -49,7 +49,7 @@ def CreateDenyAllNetworkPolicyForWorkload(
   Args:
     cluster (k8s.K8sCluster): The cluster in which to create the deny-all
         policy, and subsequently patch existing policies
-    workload (workloads.K8sWorkload): The workload in whose namespace the
+    workload (base.K8sWorkload): The workload in whose namespace the
         deny all network policy will be created, and whose pods will be tagged
         to be selected by the deny all network policy.
 

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -30,7 +30,7 @@ def DrainWorkloadNodesFromOtherPods(
         to prevent pods from appearing on the nodes again as it will be marked
         as unschedulable. Defaults to True.
   """
-  nodes = set(pod.GetNode() for pod in workload.GetCoveredPods())
+  nodes = workload.GetCoveredNodes()
   if cordon:
     for node in nodes:
       node.Cordon()

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -64,9 +64,9 @@ def IsolatePodsWithNetworkPolicy(
     return None
   if not cluster.IsNetworkPolicyEnabled():
     raise errors.OperationFailedError(
-      'NetworkPolicy is not enabled for the cluster. Creating the deny-all '
-      'NetworkPolicy will have no effect.',
-      __name__)
+        'NetworkPolicy is not enabled for the cluster. Creating the deny-all '
+        'NetworkPolicy will have no effect.',
+        __name__)
   if any(pod.namespace != pods[0].namespace for pod in pods):
     raise ValueError('Supplied pods are not in the same namespace.')
   # First create the NetworkPolicy in the workload's namespace

--- a/libcloudforensics/providers/kubernetes/mitigation.py
+++ b/libcloudforensics/providers/kubernetes/mitigation.py
@@ -35,7 +35,7 @@ def DrainWorkloadNodesFromOtherPods(
     for node in nodes:
       node.Cordon()
   for node in nodes:
-    node.Drain(lambda p: not workload.IsCoveringPod(p))
+    node.Drain(lambda pod: not workload.IsCoveringPod(pod))
 
 
 def CreateDenyAllNetworkPolicyForWorkload(
@@ -43,9 +43,12 @@ def CreateDenyAllNetworkPolicyForWorkload(
     workload: workloads.K8sWorkload) -> netpol.K8sDenyAllNetworkPolicy:
   """Isolates a workload's pods via a deny all network policy.
 
+  **Warning:** It is the caller's responsibility to make sure that Kubernetes
+  NetworkPolicy is enabled for their cluster, via their cloud provider's API.
+
   Args:
-    cluster (k8s.K8sCluster): The cluster in which to create the deny
-        all policy, and subsequently patch existing policies
+    cluster (k8s.K8sCluster): The cluster in which to create the deny-all
+        policy, and subsequently patch existing policies
     workload (workloads.K8sWorkload): The workload in whose namespace the
         deny all network policy will be created, and whose pods will be tagged
         to be selected by the deny all network policy.
@@ -54,7 +57,6 @@ def CreateDenyAllNetworkPolicyForWorkload(
     netpol.K8sDenyAllNetworkPolicy: The deny all network policy that was
         created to isolate the workload's pods.
   """
-  # TODO: Check that network policies are enabled
   # First create the NetworkPolicy in the workload's namespace
   deny_all_policy = cluster.DenyAllNetworkPolicy(workload.namespace)
   deny_all_policy.Create()

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -98,6 +98,18 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
         for pod in pods.items
     ]
 
+  def GetCoveredNodes(self) -> List[base.K8sNode]:
+    """Gets a list of Kubernetes nodes covered by this workload.
+
+    Returns:
+      List[base.K8sNode]: A list of pods covered by this workload.
+    """
+    nodes_by_name = {}  # type: Dict[str, base.K8sNode]
+    for pod in self.GetCoveredPods():
+      node = pod.GetNode()
+      nodes_by_name[node.name] = node
+    return list(nodes_by_name.values())
+
   def IsCoveringPod(self, pod: base.K8sPod) -> bool:
     """Determines whether a pod is covered by this workload.
 

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -86,18 +86,6 @@ class K8sControlledWorkload(base.K8sWorkload):
         for pod in pods.items
     ]
 
-  def GetCoveredNodes(self) -> List[base.K8sNode]:
-    """Gets a list of Kubernetes nodes covered by this workload.
-
-    Returns:
-      List[base.K8sNode]: A list of nodes covered by this workload.
-    """
-    nodes_by_name = {}  # type: Dict[str, base.K8sNode]
-    for pod in self.GetCoveredPods():
-      node = pod.GetNode()
-      nodes_by_name[node.name] = node
-    return list(nodes_by_name.values())
-
   def IsCoveringPod(self, pod: base.K8sPod) -> bool:
     """Override of abstract method."""
     # Since labels are type Dict[str, str], we can use set-like operations
@@ -114,8 +102,9 @@ class K8sDeployment(K8sControlledWorkload):
     To achieve the goal of orphaning the pods, this deployment and its matching
     ReplicaSet are deleted, without cascading.
     """
+    rs = self._ReplicaSet()
     self.Delete(cascade=False)
-    self._ReplicaSet().Delete(cascade=False)
+    rs.Delete(cascade=False)
 
   def Delete(self, cascade: bool = True) -> None:
     """Override of abstract method."""

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -46,7 +46,7 @@ class K8sControlledWorkload(base.K8sWorkload):
   def OrphanPods(self) -> None:
     """Orphans the pods covered by this workload.
 
-    Note that calling this function may entail the deletion of the object
+    Note that calling this function will entail the deletion of the object
     upon which this method was called.
     """
 

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -24,10 +24,10 @@ from libcloudforensics.providers.kubernetes import base
 from libcloudforensics.providers.kubernetes import selector
 
 
-class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
-  """Abstract class representing Kubernetes workloads.
+class K8sControlledWorkload(base.K8sWorkload):
+  """Abstract class representing workloads covering pods with via a selector.
 
-  A Kubernetes workload could be a ReplicaSet, a Deployment, a StatefulSet.
+  Examples: ReplicaSet, Deployment, StatefulSet.
   """
 
   @abc.abstractmethod
@@ -48,14 +48,6 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
 
     Note that calling this function may entail the deletion of the object
     upon which this method was called.
-    """
-
-  @abc.abstractmethod
-  def AddTemplateLabels(self, labels: Dict[str, str]) -> None:
-    """Adds labels to the pod template spec of this deployment.
-
-    Args:
-      labels (Dict[str, str]): The labels to be added to the pod template spec.
     """
 
   def MatchLabels(self) -> Dict[str, str]:
@@ -79,11 +71,7 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
     return match_labels
 
   def GetCoveredPods(self) -> List[base.K8sPod]:
-    """Gets a list of Kubernetes pods covered by this workload.
-
-    Returns:
-      List[base.K8sPod]: A list of pods covered by this workload.
-    """
+    """Override of abstract method."""
     api = self._Api(client.CoreV1Api)
 
     labels_selector = selector.K8sSelector.FromLabelsDict(
@@ -98,51 +86,15 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
         for pod in pods.items
     ]
 
-  def GetCoveredNodes(self) -> List[base.K8sNode]:
-    """Gets a list of Kubernetes nodes covered by this workload.
-
-    Returns:
-      List[base.K8sNode]: A list of nodes covered by this workload.
-    """
-    nodes_by_name = {}  # type: Dict[str, base.K8sNode]
-    for pod in self.GetCoveredPods():
-      node = pod.GetNode()
-      nodes_by_name[node.name] = node
-    return list(nodes_by_name.values())
-
   def IsCoveringPod(self, pod: base.K8sPod) -> bool:
-    """Determines whether a pod is covered by this workload.
-
-    This function checks if this workload's pod match labels are a subset of the
-    given pod's labels.
-
-    Args:
-      pod (base.K8sPod): The pod to be checked with the labels of this workload.
-
-    Returns:
-      bool: True if the pod is covered this workload, False otherwise.
-    """
+    """Override of abstract method."""
     # Since labels are type Dict[str, str], we can use set-like operations
     # on the items of the dict
     return self._PodMatchLabels().items() <= pod.GetLabels().items()
 
 
-class K8sDeployment(K8sWorkload):
+class K8sDeployment(K8sControlledWorkload):
   """Class representing a Kubernetes deployment."""
-
-  def AddTemplateLabels(self, labels: Dict[str, str]) -> None:
-    """Override of abstract method."""
-    api = self._Api(client.AppsV1Api)
-    api.patch_namespaced_deployment(
-        self.name,
-        self.namespace,
-        body={'spec': {
-            'template': {
-                'metadata': {
-                    'labels': labels
-                }
-            }
-        }})
 
   def OrphanPods(self) -> None:
     """Override of abstract method.
@@ -207,22 +159,8 @@ class K8sDeployment(K8sWorkload):
     return self._ReplicaSet().MatchLabels()
 
 
-class K8sReplicaSet(K8sWorkload):
+class K8sReplicaSet(K8sControlledWorkload):
   """Class representing a Kubernetes deployment."""
-
-  def AddTemplateLabels(self, labels: Dict[str, str]) -> None:
-    """Override of abstract method."""
-    api = self._Api(client.AppsV1Api)
-    api.patch_namespaced_replica_set(
-        self.name,
-        self.namespace,
-        body={'spec': {
-            'template': {
-                'metadata': {
-                    'labels': labels
-                }
-            }
-        }})
 
   def OrphanPods(self) -> None:
     """Override of abstract method."""

--- a/libcloudforensics/providers/kubernetes/workloads.py
+++ b/libcloudforensics/providers/kubernetes/workloads.py
@@ -102,7 +102,7 @@ class K8sWorkload(base.K8sNamespacedResource, metaclass=abc.ABCMeta):
     """Gets a list of Kubernetes nodes covered by this workload.
 
     Returns:
-      List[base.K8sNode]: A list of pods covered by this workload.
+      List[base.K8sNode]: A list of nodes covered by this workload.
     """
     nodes_by_name = {}  # type: Dict[str, base.K8sNode]
     for pod in self.GetCoveredPods():

--- a/tests/providers/kubernetes/test_base.py
+++ b/tests/providers/kubernetes/test_base.py
@@ -28,6 +28,8 @@ from tests.providers.kubernetes import k8s_mocks
 class K8sClusterTest(unittest.TestCase):
   """Test K8sCluster functionality, mainly checking API calls."""
 
+  # pylint: disable=abstract-class-instantiated
+
   @typing.no_type_check
   @mock.patch('kubernetes.client.CoreV1Api')
   def testClusterListNodes(self, mock_k8s_api):

--- a/tests/providers/kubernetes/test_base.py
+++ b/tests/providers/kubernetes/test_base.py
@@ -23,7 +23,8 @@ from libcloudforensics.providers.kubernetes import base
 from libcloudforensics.providers.kubernetes import cluster
 from tests.providers.kubernetes import k8s_mocks
 
-
+# Make K8sCluster instantiable
+@mock.patch.object(cluster.K8sCluster, '__abstractmethods__', ())
 class K8sClusterTest(unittest.TestCase):
   """Test K8sCluster functionality, mainly checking API calls."""
 


### PR DESCRIPTION
- Move the `K8sWorkload` abstract class higher up the hierarchy so that `K8sPod` can inherit from it, old `K8sWorkload` becomes `K8sControlledWorkload`
- Make `K8sCluster` an abstract class to be subclassed in the cloud provider packages (making `GkeCluster.GetK8sCluster` obsolete)
- Integrate NetworkPolicy check directly in isolation function
- Remove now unused method `AddTemplateLabels`
- Add a couple extra methods to `K8sCluster`
- Make `K8sDeployment.OrphanPods` more stable by saving the replica set before deletion