### PR TITLE
Add owner label to GCP vms

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -673,9 +673,13 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
 
     # TODO(ramo-j) Better than OS login would be the user authenticated to gcp,
     # but I cannt find a way to determine that.
-    if owner_label and os.getlogin():
-      owner = re.sub('[^-_a-z0-9]', '_', os.getlogin())
-      request_body['labels'] = [{'owner':owner}]
+    try:
+      if owner_label and os.getlogin():
+        owner = re.sub('[^-_a-z0-9]', '_', os.getlogin())
+        request_body['labels'] = [{'owner':owner}]
+    except OSError as exception:
+      # If run as an automated user, no user can be found.
+      pass
     return self.CreateInstanceFromRequest(request_body, compute_zone)
 
   def GetOrCreateAnalysisVm(

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -676,7 +676,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     try:
       if owner_label and os.getlogin():
         owner = re.sub('[^-_a-z0-9]', '_', os.getlogin())
-        request_body['labels'] = [{'owner':owner}]
+        request_body['labels'] = [{'owner': owner}]
     except OSError:
       # If run as an automated user, no user can be found.
       pass

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -15,6 +15,7 @@
 """Google Compute Engine functionalities."""
 
 import os
+import re
 import subprocess
 import time
 from collections import defaultdict
@@ -567,7 +568,8 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
           List[Union['GoogleComputeDisk',
           'GoogleRegionComputeDisk']]] = None,
       network_name: str = 'default',
-      external_ip: bool = True
+      external_ip: bool = True,
+      owner_label: bool = True
   ) -> 'GoogleComputeInstance':
     """Create a compute instance.
 
@@ -592,6 +594,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
       data_disks: List of disks to attach to the instance, default mode is READ_ONLY.
       network_name: Name of the VPC network to use, "default" network is default.
       external_ip: True if the instance should have an external IP.
+      owner_label: True if the instance should have an owner label.
 
     Returns:
       Compute instance object.
@@ -667,6 +670,12 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
         }]
     }
     request_body['networkInterfaces'] = [network_interface]
+
+    # TODO(ramo-j) Better than OS login would be the user authenticated to gcp,
+    # but I cannt find a way to determine that.
+    if owner_label and os.getlogin():
+      owner = re.sub('[^-_a-z0-9]', '_', "ramoj@google.com")
+      request_body['labels'] = [{'owner':owner}]
     return self.CreateInstanceFromRequest(request_body, compute_zone)
 
   def GetOrCreateAnalysisVm(

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -677,7 +677,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
       if owner_label and os.getlogin():
         owner = re.sub('[^-_a-z0-9]', '_', os.getlogin())
         request_body['labels'] = [{'owner':owner}]
-    except OSError as exception:
+    except OSError:
       # If run as an automated user, no user can be found.
       pass
     return self.CreateInstanceFromRequest(request_body, compute_zone)

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -674,7 +674,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     # TODO(ramo-j) Better than OS login would be the user authenticated to gcp,
     # but I cannt find a way to determine that.
     if owner_label and os.getlogin():
-      owner = re.sub('[^-_a-z0-9]', '_', "ramoj@google.com")
+      owner = re.sub('[^-_a-z0-9]', '_', os.getlogin())
       request_body['labels'] = [{'owner':owner}]
     return self.CreateInstanceFromRequest(request_body, compute_zone)
 

--- a/libcloudforensics/providers/kubernetes/enumerations/base.py
+++ b/libcloudforensics/providers/kubernetes/enumerations/base.py
@@ -151,7 +151,7 @@ class Enumeration(Generic[ObjT], metaclass=abc.ABCMeta):
 
     row_max_len = max(
         len(MakeRow(item))
-        for item in (list(info.items()) + list(warnings.items())))
+        for item in list(info.items()) + list(warnings.items()))
     separator = '-' * row_max_len
 
     print_func(separator, logging.INFO)


### PR DESCRIPTION
What is says on the tin, really. Owner is sourced as the current logged in user. Preferable would be the user authenticated to GCP but I have been unable to identify a method for discovering that.

But also, a small change for linter appeasement. 