### PR TITLE
[azure] add image_reference option, fix multi-subscriptions bug, docs

### DIFF
--- a/libcloudforensics/providers/azure/forensics.py
+++ b/libcloudforensics/providers/azure/forensics.py
@@ -76,7 +76,11 @@ def CreateDiskCopy(
     raise ValueError(
         'You must specify at least one of [instance_name, disk_name].')
 
-  src_account = account.AZAccount(
+  if src_profile and dst_profile and src_profile != dst_profile:
+    src_account = account.AZAccount(
+      None, default_region=region, profile_name=src_profile)
+  else:
+    src_account = account.AZAccount(
       resource_group_name, default_region=region, profile_name=src_profile)
   dst_account = account.AZAccount(resource_group_name,
                                   default_region=region,
@@ -141,6 +145,7 @@ def StartAnalysisVm(
     memory_in_mb: int = 8192,
     region: str = 'eastus',
     attach_disks: Optional[List[str]] = None,
+    image_reference: Optional[Dict[str, str]] = None,
     tags: Optional[Dict[str, str]] = None,
     dst_profile: Optional[str] = None
     ) -> Tuple['compute.AZComputeVirtualMachine', bool]:
@@ -164,6 +169,9 @@ def StartAnalysisVm(
     region (str): Optional. The region in which to create the VM.
         Default is eastus.
     attach_disks (List[str]): Optional. List of disk names to attach to the VM.
+    image_reference (Dict[str, str]): Optional. A dictionary of Azure image
+        to bootstrap. It can be usual sku/publisher/version/offer or shared
+        image id.
     tags (Dict[str, str]): Optional. A dictionary of tags to add to the
         instance, for example {'TicketID': 'xxx'}. An entry for the instance
         name is added by default.
@@ -188,6 +196,7 @@ def StartAnalysisVm(
       cpu_cores,
       memory_in_mb,
       ssh_public_key,
+      image_reference=image_reference,
       tags=tags)
 
   for disk_name in (attach_disks or []):

--- a/libcloudforensics/providers/azure/internal/account.py
+++ b/libcloudforensics/providers/azure/internal/account.py
@@ -42,7 +42,7 @@ class AZAccount:
   """
 
   def __init__(self,
-               default_resource_group_name: str,
+               default_resource_group_name: Optional[str] = None,
                default_region: str = 'eastus',
                profile_name: Optional[str] = None) -> None:
     """Initialize the AZAccount class.
@@ -66,8 +66,11 @@ class AZAccount:
     self._network = None  # type: Optional[network_module.AZNetwork]
     self._resource = None  # type: Optional[resource_module.AZResource]
     self._storage = None  # type: Optional[storage_module.AZStorage]
-    self.default_resource_group_name = self.resource.GetOrCreateResourceGroup(
-        default_resource_group_name)
+    if default_resource_group_name:
+      self.default_resource_group_name = self.resource.GetOrCreateResourceGroup(
+          default_resource_group_name)
+    else:
+      self.default_resource_group_name = None
 
   @property
   def compute(self) -> compute_module.AZCompute:

--- a/libcloudforensics/providers/azure/internal/compute.py
+++ b/libcloudforensics/providers/azure/internal/compute.py
@@ -377,6 +377,7 @@ class AZCompute:
       ssh_public_key: str,
       region: Optional[str] = None,
       packages: Optional[List[str]] = None,
+      image_reference: Optional[Dict[str, str]] = None,
       tags: Optional[Dict[str, str]] = None
   ) -> Tuple['AZComputeVirtualMachine', bool]:
     """Get or create a new virtual machine for analysis purposes.
@@ -393,6 +394,9 @@ class AZCompute:
           provided, the vm will be created in the default_region
           associated to the AZAccount object.
       packages (List[str]): Optional. List of packages to install in the VM.
+      image_reference (Dict[str, str]): Optional. A dictionary of Azure image
+          to bootstrap. It can be usual sku/publisher/version/offer or shared
+          image id.
       tags (Dict[str, str]): Optional. A dictionary of tags to add to the
           instance, for example {'TicketID': 'xxx'}. An entry for the
           instance name is added by default.
@@ -432,16 +436,20 @@ class AZCompute:
     if not region:
       region = self.az_account.default_region
 
+    if not image_reference:
+      image_reference = {
+                    'sku': common.UBUNTU_1804_SKU,
+                    'publisher': 'Canonical',
+                    'version': 'latest',
+                    'offer': 'UbuntuServer'}
+    logger.debug('VM image_reference {}'.format(image_reference))
+
     creation_data = {
         'location': region,
         'properties': {
             'hardwareProfile': {'vmSize': instance_type},
             'storageProfile': {
-                'imageReference': {
-                    'sku': common.UBUNTU_1804_SKU,
-                    'publisher': 'Canonical',
-                    'version': 'latest',
-                    'offer': 'UbuntuServer'}
+                'imageReference': image_reference
             },
             'osDisk': {
                 'caching': 'ReadWrite',

--- a/tools/az_cli.py
+++ b/tools/az_cli.py
@@ -15,6 +15,7 @@
 """Demo CLI tool for Azure."""
 
 import os
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING
 from Crypto.PublicKey import RSA
@@ -100,6 +101,10 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
       logger.error('error: parameter --attach_disks: {0:s}'.format(
           args.attach_disks))
       return
+  if args.image_reference:
+    image_reference = json.loads(args.image_reference)
+  else:
+    image_reference = None
 
   ssh_public_key = args.ssh_public_key
   if not ssh_public_key:
@@ -118,7 +123,8 @@ def StartAnalysisVm(args: 'argparse.Namespace') -> None:
                                  memory_in_mb=int(args.memory_in_mb),
                                  region=args.region,
                                  attach_disks=attach_disks,
-                                 dst_profile=args.dst_profile)
+                                 dst_profile=args.dst_profile,
+                                 image_reference=image_reference)
 
   logger.info('Analysis VM started.')
   logger.info('Name: {0:s}, Started: {1:s}'.format(vm[0].name, str(vm[1])))

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -318,6 +318,8 @@ def Main() -> None:
                 ('--disk_size', 'Size of disk in GB.', 50),
                 ('--cpu_cores', 'Instance CPU core count.', 4),
                 ('--memory_in_mb', 'Instance amount of RAM memory.', 8192),
+                ('--image_reference', 'VM image to use (default: Bionic).',
+                 None),
                 ('--region', 'The region in which to create the VM. If not '
                              'provided, the VM will be created in the '
                              '"eastus" region.', 'eastus'),


### PR DESCRIPTION
* adding image_reference option: this allows to use a different sku than default one (bionic) and also to use a shared gallery image with any custom image
* fix multi-subscription bug: previous state was checking existing of resource_group_name in src_profile which works fine if src and dst subscriptions are the same but not if different
* docs: more details especially on app token creation, azure permissions, and image_reference
