### PR TITLE
Updated snapshot behaviour for when the resource exists already

### DIFF
--- a/libcloudforensics/providers/gcp/forensics.py
+++ b/libcloudforensics/providers/gcp/forensics.py
@@ -86,15 +86,16 @@ def CreateDiskCopy(
       disk_type = disk_to_copy.GetDiskType()
 
     logger.info('Disk copy of {0:s} started...'.format(disk_to_copy.name))
-    snapshot = disk_to_copy.Snapshot()
+    snapshot, created = disk_to_copy.Snapshot()
     logger.debug('Snapshot created: {0:s}'.format(snapshot.name))
     new_disk = dst_project.compute.CreateDiskFromSnapshot(
         snapshot, disk_name_prefix='evidence', disk_type=disk_type)
     logger.info(
         'Disk {0:s} successfully copied to {1:s}'.format(
             disk_to_copy.name, new_disk.name))
-    snapshot.Delete()
-    logger.debug('Snapshot {0:s} deleted.'.format(snapshot.name))
+    if created:
+      snapshot.Delete()
+      logger.debug('Snapshot {0:s} deleted.'.format(snapshot.name))
 
   except (RefreshError, DefaultCredentialsError) as exception:
     raise errors.CredentialsConfigurationError(

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -1891,7 +1891,9 @@ class GoogleComputeDisk(compute_base_resource.GoogleComputeBaseResource):
     return response
 
   def Snapshot(
-      self, snapshot_name: Optional[str] = None) -> 'GoogleComputeSnapshot':
+      self,
+      snapshot_name: Optional[str] = None) -> Tuple['GoogleComputeSnapshot',
+                                                    bool]:
     """Create Snapshot of the disk.
 
     The Snapshot name must comply with the following RegEx:

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -1937,9 +1937,9 @@ class GoogleComputeDisk(compute_base_resource.GoogleComputeBaseResource):
     try:
       response = request.execute()
       self.BlockOperation(response, zone=self.zone)
-    except RuntimeError as e:
-      if 'already exists' not in str(e):
-        raise e
+    except RuntimeError as error:
+      if 'already exists' not in str(error):
+        raise error
       logger.info('Reusing existing snapshot {0:s}'.format(snapshot_name))
       created = False
     return GoogleComputeSnapshot(disk=self, name=snapshot_name), created

--- a/tests/providers/azure/internal/test_storage.py
+++ b/tests/providers/azure/internal/test_storage.py
@@ -26,8 +26,8 @@ class AZStorageTest(unittest.TestCase):
   """Test Azure storage class."""
   # pylint: disable=line-too-long
 
-  @mock.patch('azure.mgmt.storage.v2021_06_01.operations._storage_accounts_operations.StorageAccountsOperations.list_keys')
-  @mock.patch('azure.mgmt.storage.v2021_06_01.operations._storage_accounts_operations.StorageAccountsOperations.begin_create')
+  @mock.patch('azure.mgmt.storage.v2021_08_01.operations._storage_accounts_operations.StorageAccountsOperations.list_keys')
+  @mock.patch('azure.mgmt.storage.v2021_08_01.operations._storage_accounts_operations.StorageAccountsOperations.begin_create')
   @typing.no_type_check
   def testCreateStorageAccount(self, mock_create, mock_list_keys):
     """Test that a storage account is created and its information retrieved"""

--- a/tests/providers/gcp/internal/test_compute.py
+++ b/tests/providers/gcp/internal/test_compute.py
@@ -608,13 +608,13 @@ class GoogleComputeDiskTest(unittest.TestCase):
     mock_block_operation.return_value = None
 
     # Snapshot(snapshot_name=None). Snapshot should start with the disk's name
-    snapshot = gcp_mocks.FAKE_DISK.Snapshot()
+    snapshot, _ = gcp_mocks.FAKE_DISK.Snapshot()
     self.assertIsInstance(snapshot, compute.GoogleComputeSnapshot)
     self.assertTrue(snapshot.name.startswith('fake-disk'))
 
     # Snapshot(snapshot_name='my-Snapshot'). Snapshot should start with
     # 'my-Snapshot'
-    snapshot = gcp_mocks.FAKE_DISK.Snapshot(snapshot_name='my-snapshot')
+    snapshot, _ = gcp_mocks.FAKE_DISK.Snapshot(snapshot_name='my-snapshot')
     self.assertIsInstance(snapshot, compute.GoogleComputeSnapshot)
     self.assertTrue(snapshot.name.startswith('my-snapshot'))
 


### PR DESCRIPTION
Currently implementation is that when attempting to snapshot a disk in GCE, if the snapshot exists already, an error is thrown. This PR captures that and returns the existing snapshot in such an event. The creation is also tracked, so the snapshot is only deleted if the snapshot was created anew. 

Also, unrelated updates for Azure tests.