### PR TITLE
Added in retry on CreateDiskFromSnapshot when snapshot isn't yet ready

### DIFF
--- a/libcloudforensics/__init__.py
+++ b/libcloudforensics/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """libcloud forensics module."""
 
-__version__ = '20220114'
+__version__ = '20220221'

--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -408,7 +408,7 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
           response = request.execute()
           break
         except HttpError as exception:
-          if not 'is not ready' in str(exception):
+          if 'is not ready' not in str(exception):
             raise exception
           logger.warning("Resource not yet ready, pausing 30 seconds...")
           time.sleep(30)


### PR DESCRIPTION
Pretty much what it says on the tin - When the snapshot being used to create a disk isn't ready yet, wait for the snapshot to become ready. 