### PR TITLE
Add randomness to snapshot names

### DIFF
--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -152,6 +152,7 @@ def GenerateUniqueInstanceName(
     name = name[:truncate_at]
   return name
 
+
 def CreateService(
     service_name: str,
     api_version: str) -> 'googleapiclient.discovery.Resource':

--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -147,9 +147,9 @@ def GenerateUniqueInstanceName(
   """
   rand = ''.join(random.choices(string.ascii_lowercase, k=5))
   timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
-  name = f'{prefix}-{rand}-{timestamp}'
   if truncate_at:
-    name = name[:truncate_at]
+    prefix = prefix[:(truncate_at - len(timestamp) - 7)]
+  name = f'{prefix}-{rand}-{timestamp}'
   return name
 
 

--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -16,8 +16,10 @@
 
 import binascii
 import datetime
+import random
 import re
 import socket
+import string
 import time
 from typing import TYPE_CHECKING, Dict, List, Optional, Any
 import netaddr
@@ -143,12 +145,12 @@ def GenerateUniqueInstanceName(
     str: The name after adding a timestamp.
         Ex: [prefix]-[TIMESTAMP('%Y%m%d%H%M%S')]
   """
+  rand = ''.join(random.choices(string.ascii_lowercase, k=5))
   timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+  name = f'{prefix}-{rand}-{timestamp}'
   if truncate_at:
-    truncate_at = truncate_at - len(timestamp) - 1
-  name = '{0:s}-{1:s}'.format(prefix[:truncate_at], timestamp)
+    name = name[:truncate_at]
   return name
-
 
 def CreateService(
     service_name: str,

--- a/libcloudforensics/providers/gcp/internal/common.py
+++ b/libcloudforensics/providers/gcp/internal/common.py
@@ -143,7 +143,7 @@ def GenerateUniqueInstanceName(
 
   Returns:
     str: The name after adding a timestamp.
-        Ex: [prefix]-[TIMESTAMP('%Y%m%d%H%M%S')]
+        Ex: [prefix]-[rand]-[TIMESTAMP('%Y%m%d%H%M%S')]
   """
   rand = ''.join(random.choices(string.ascii_lowercase, k=5))
   timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')


### PR DESCRIPTION
If there is parallel usage of the CopyDisk operation, the intermediate snapshots can end up with the same names and an error to create the snapshot, since it is based on timestamp. Adding some randomness to the name.