### PR TITLE
Detach disk uses disk name instead of device name

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -1368,11 +1368,15 @@ class GoogleComputeInstance(compute_base_resource.GoogleComputeBaseResource):
     """
 
     gce_instance_client = self.GceApi().instances()
+    device_name = None
+    for disk_dict in self.GetValue('disks'):
+      if disk_dict['source'].split('/')[-1] == disk.name:
+        device_name = disk_dict['deviceName']
     request = gce_instance_client.detachDisk(
         instance=self.name,
         project=self.project_id,
         zone=self.zone,
-        deviceName=disk.name)
+        deviceName=device_name)
     response = request.execute()
     self.BlockOperation(response, zone=self.zone)
 


### PR DESCRIPTION
Detach disk uses disk name instead of device name, these can be different. From docs[0]: DeviceName: Specifies a unique device name of your choice that is reflected into the /dev/disk/by-id/google-* tree of a Linux operating system running within the instance. This name can be used to reference the device for mounting, resizing, and so on, from within the instance. If not specified, the server chooses a default device name to apply to this disk.

[0] https://cloud.google.com/compute/docs/reference/rest/v1/instances/get