### PR TITLE
Bugfix: truncate name before regex validation

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -962,12 +962,12 @@ class GoogleCloudCompute(common.GoogleCloudComputeClient):
     """
 
     if name:
+      name = name[:common.COMPUTE_NAME_LIMIT]
       if not common.REGEX_DISK_NAME.match(name):
         raise errors.InvalidNameError(
             'Image name {0:s} does not comply with {1:s}'.format(
                 name, common.REGEX_DISK_NAME.pattern),
             __name__)
-      name = name[:common.COMPUTE_NAME_LIMIT]
     else:
       name = common.GenerateUniqueInstanceName(
           src_disk.name, common.COMPUTE_NAME_LIMIT)


### PR DESCRIPTION
The regex would never be valid if the name was too long. Conversely, the truncate statement would never have any effect, as only short-enough names would get truncated.