### PR TITLE
Print the log lines for querylogs instead of logging them

### DIFF
--- a/tools/gcp_cli.py
+++ b/tools/gcp_cli.py
@@ -196,7 +196,7 @@ def QueryLogs(args: 'argparse.Namespace') -> None:
   results = logs.ExecuteQuery(qfilter.split(',') if qfilter else None)
   logger.info('Found {0:d} log entries:'.format(len(results)))
   for line in results:
-    logger.info(json.dumps(line))
+    print(json.dumps(line))
 
 
 def CreateDiskFromGCSImage(args: 'argparse.Namespace') -> None:


### PR DESCRIPTION
Fixes #465 

Before:
```
[2023-05-18 14:58:15,465] [tools.gcp_cli       ] INFO     {"protoPayload": {"@type": "type.googleapis.com/google.cloud.audit.AuditLog", "authenticationInfo": {"principalEmail": "system@google.com"}, "serviceName": "compute.googleapis.com", "methodName": "NotifySubnetworkCreationLocation", "request": {"@type": "type.googleapis.com/NotifySubnetworkCreationLocation"}, "metadata": {"currentLocations": ["europe-west9"], "@type": "type.googleapis.com/google.cloud.audit.ResourceLocation"}}, "insertId": "4l2", "resource": {"type": "gce_subnetwork", "labels": {"subnetwork_name": "default", "project_id": "xxxx", "subnetwork_id": "1234", "location": "europe-west9"}}, "timestamp": "2022-04-23T01:20:54.750103Z", "severity": "INFO", "logName": "projects/xxxx/logs/cloudaudit.googleapis.com%2Fsystem_event", "receiveTimestamp": "2022-04-23T01:20:55.422920649Z"}
```

After:
```
{"protoPayload": {"@type": "type.googleapis.com/google.cloud.audit.AuditLog", "authenticationInfo": {"principalEmail": "system@google.com"}, "serviceName": "compute.googleapis.com", "methodName": "NotifySubnetworkCreationLocation", "request": {"@type": "type.googleapis.com/NotifySubnetworkCreationLocation"}, "metadata": {"currentLocations": ["europe-west9"], "@type": "type.googleapis.com/google.cloud.audit.ResourceLocation"}}, "insertId": "4l2", "resource": {"type": "gce_subnetwork", "labels": {"subnetwork_name": "default", "subnetwork_id": "1234", "location": "europe-west9", "project_id": "xxxx"}}, "timestamp": "2022-04-23T01:20:54.750103Z", "severity": "INFO", "logName": "projects/xxxx/logs/cloudaudit.googleapis.com%2Fsystem_event", "receiveTimestamp": "2022-04-23T01:20:55.422920649Z"}
```