### PR TITLE
Add timeout to build step of cloudbuild export image  method.

### DIFF
--- a/libcloudforensics/providers/gcp/internal/compute.py
+++ b/libcloudforensics/providers/gcp/internal/compute.py
@@ -2289,6 +2289,7 @@ class GoogleComputeImage(compute_base_resource.GoogleComputeBaseResource):
     build_args = [
         '-source_image={0:s}'.format(self.name),
         '-destination_uri={0:s}'.format(full_path),
+        '-timeout=86400s',
         '-client_id=api',
     ]
     if image_format:

--- a/tests/providers/gcp/test_forensics.py
+++ b/tests/providers/gcp/test_forensics.py
@@ -177,4 +177,3 @@ class GCPForensicsTest(unittest.TestCase):
         gcs_output_folder=f'gs://{dest_bucket_name}/{"/path/to/directory/"}',
         image_format='qcow2',
         output_name=mock_disk_obj.name)
-  


### PR DESCRIPTION
Add 24h timeout to the export image cloudbuild step as cloudbuild has an overall timeout and a separate timeout per buildstep.

* fixed py-linting error